### PR TITLE
Prepare v0.9.0: performance, release tooling, doctest + correctness tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ dependencies
 __pycache__/
 *.pyc
 
+# Transient perf output (the committed reference is perf/baseline.csv)
+/optics_perf.csv
+optics_perf.csv
+
 #Output
 *.ppm
 !*/Opencv_ClusterImage_Test/ClusterImage_*.ppm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,6 @@ First modernized release: a fast, dependency-free, cross-platform C++20 library.
 ### Fixed
 - nanoflann's L2 metric works in squared distance; the backend now squares the search
   radius (the old nanoflann path searched an unsquared radius).
+- `epsilon_estimation` uses only the non-degenerate dimensions, so collinear/planar inputs
+  get a sensible auto-epsilon instead of collapsing to a magic `1.0` fallback (which now
+  applies only to truly all-identical points, where the value is immaterial).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to OPTICS-Clustering are documented here. The format is based
+on [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
+[Semantic Versioning](https://semver.org/).
+
+## [0.9.0] — unreleased
+
+First modernized release: a fast, dependency-free, cross-platform C++20 library.
+
+### Added
+- C++20 runtime API `compute_reachability_dists<T, Dim, Backend>(points, min_pts,
+  epsilon = -1, mode = Precompute, n_threads = 0)` — coordinate type and dimension
+  are deduced from the cloud; no compile-time point count.
+- Swappable neighbor-search backend via a `NeighborSearch` concept. Default
+  `NanoflannBackend` (zero-copy adaptor over the user's `vector<array<T,Dim>>`);
+  optional `BoostRTreeBackend` behind `OPTICS_ENABLE_BOOST_RTREE`.
+- `NeighborMode::Precompute` (parallel) / `OnDemand` (lean memory) acquisition with a
+  portable thread pool (`n_threads`, 0 ⇒ hardware concurrency).
+- Dimension-agnostic CSV export (`optics/io.hpp`) and `tools/visualize.py`
+  (matplotlib 2D/3D/PCA scatter + reachability plot).
+- N-dimensional synthetic-data generators (`optics/testdata.hpp`).
+- `optics/version.hpp` (`OPTICS_VERSION*`, `optics::version()`).
+- CMake presets (msvc / linux-gcc / linux-clang) and a GitHub Actions CI matrix
+  (Linux GCC/Clang, Windows MSVC, plus a Boost-backend job).
+- Test/benchmark tooling: doctest unit suite, nanobench perf-regression harness with a
+  committed baseline, and a 1e6–1e7 scale harness.
+
+### Changed
+- Removed all external dependencies (FunctionalPlus, CrikeeIP/Geometry). Only nanoflann
+  (BSD 2-Clause) is vendored; everything else is the standard library.
+- Default neighbor search is nanoflann (refreshed to the latest upstream).
+- Library errors throw exceptions instead of calling `std::exit`.
+
+### Removed
+- The custom compile-time-sized `kdt::KDTree` backend and the `n_points` template
+  parameter it forced.
+- Built-in C++ image rendering (replaced by CSV export + matplotlib).
+
+### Performance
+- `compute_core_dist`: reuse a thread-local distance buffer — ~2.2–2.7× on the hot path.
+- Seed queue: lazy-deletion min-heap instead of `std::set` — ~14–17% faster ordering.
+- Validated to 1e7 points (3D); see `perf/README.md`.
+
+### Fixed
+- nanoflann's L2 metric works in squared distance; the backend now squares the search
+  radius (the old nanoflann path searched an unsquared radius).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ cmake --build build --config Release
 ctest --test-dir build -C Release --output-on-failure
 ```
 
-- **Run one suite:** `ctest --preset msvc -R optics_tests` (suites: `optics_tests`, `optics_visual_test`), or run the built exe directly (`build/test/Release/optics_tests.exe`).
-- **Tests use `assert()`** for verification. The test targets force assertions on via `/UNDEBUG` (MSVC) / `-UNDEBUG` (GCC/Clang) — never rely on `-DNDEBUG` builds passing meaningfully.
+- **Run one suite:** `ctest --preset msvc -R optics_tests` (suites: `optics_tests`, `optics_visual_test`), or run the built exe directly (`build/test/Release/optics_tests.exe`). Use `ctest --output-on-failure` to see doctest's per-case report.
+- **Unit suite uses [doctest](https://github.com/doctest/doctest)** (`test/third_party/doctest.h`, vendored, test-only): `optics_tests` is `TEST_CASE`/`CHECK`-based, so assertions run regardless of `NDEBUG`. Note: doctest can't decompose `&&`/`||` in a `CHECK` — wrap such expressions in parens. The separate `optics_visual_test` still verifies via `assert()`, so it keeps `/UNDEBUG` (MSVC) / `-UNDEBUG` (GCC/Clang).
 - **Optional Boost backend:** configure with `-DOPTICS_ENABLE_BOOST_RTREE=ON` (needs Boost.Geometry). This compiles `BoostRTreeBackend` and an `#ifdef`-gated equivalence test. Boost is exercised in CI (`.github/workflows/ci.yml`), not in the default build.
 - **Benchmark:** build the `optics_benchmark` target (Release) and run it; an optional integer arg scales the point counts (`optics_benchmark 4`). Not a ctest.
 - **Local toolchain note:** on the original dev machine only VS2022 is installed (no g++/standalone cmake on PATH); use its bundled cmake at `…\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(OPTICS-Clustering LANGUAGES CXX)
+project(OPTICS-Clustering VERSION 0.9.0 LANGUAGES CXX)
 
 # Optional Boost.Geometry rtree neighbor-search backend. OFF by default so the
 # library builds with no external dependencies (only the vendored nanoflann).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,22 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 
 project(OPTICS-Clustering VERSION 0.9.0 LANGUAGES CXX)
 
 # Optional Boost.Geometry rtree neighbor-search backend. OFF by default so the
 # library builds with no external dependencies (only the vendored nanoflann).
 option(OPTICS_ENABLE_BOOST_RTREE "Enable the optional Boost rtree backend" OFF)
-option(OPTICS_BUILD_TESTS "Build the OPTICS test suite" ON)
+option(OPTICS_BUILD_TESTS "Build the OPTICS test suite" ${PROJECT_IS_TOP_LEVEL})
+option(OPTICS_INSTALL "Generate install/package rules" ${PROJECT_IS_TOP_LEVEL})
 
+include(GNUInstallDirs)  # defines CMAKE_INSTALL_INCLUDEDIR (used below) before first use
 find_package(Threads REQUIRED)
 
 # Header-only library, consumed as an INTERFACE target.
 add_library(optics INTERFACE)
 add_library(optics::optics ALIAS optics)
-target_include_directories(optics INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(optics INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_features(optics INTERFACE cxx_std_20)
 target_link_libraries(optics INTERFACE Threads::Threads)
 
@@ -25,4 +29,32 @@ endif()
 if(OPTICS_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
+endif()
+
+# Install + package config so downstream can `find_package(optics)` or FetchContent.
+if(OPTICS_INSTALL)
+    include(CMakePackageConfigHelpers)
+
+    set(OPTICS_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/optics")
+
+    install(TARGETS optics EXPORT opticsTargets)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/optics"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    install(EXPORT opticsTargets
+            FILE opticsTargets.cmake
+            NAMESPACE optics::
+            DESTINATION "${OPTICS_CMAKE_DIR}")
+
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/opticsConfig.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/opticsConfig.cmake"
+        INSTALL_DESTINATION "${OPTICS_CMAKE_DIR}")
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/opticsConfigVersion.cmake"
+        VERSION "${PROJECT_VERSION}"
+        COMPATIBILITY SameMajorVersion)
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/opticsConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/opticsConfigVersion.cmake"
+        DESTINATION "${OPTICS_CMAKE_DIR}")
 endif()

--- a/LICENSE
+++ b/LICENSE
@@ -6,3 +6,10 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+This product bundles third-party components. The vendored nanoflann library is
+licensed under the BSD 2-Clause license; the test-only doctest and nanobench
+libraries under the MIT license. Full texts and copyright notices are in
+THIRD-PARTY-LICENSES.md.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ python tools/visualize.py --points points.csv --reach reach.csv --out plot.png
 
 ## Dependencies
 
-None required: [nanoflann](https://github.com/jlblancoc/nanoflann) is vendored under `include/optics/`, and everything else is the C++ standard library. **Boost** is an optional alternative neighbor-search backend, enabled with `-DOPTICS_ENABLE_BOOST_RTREE=ON`.
+None required: [nanoflann](https://github.com/jlblancoc/nanoflann) (BSD 2-Clause) is vendored under `include/optics/`, and everything else is the C++ standard library. **Boost** is an optional alternative neighbor-search backend, enabled with `-DOPTICS_ENABLE_BOOST_RTREE=ON`. Bundled third-party licenses are listed in [`THIRD-PARTY-LICENSES.md`](THIRD-PARTY-LICENSES.md).
 
 ## Building & testing
 
@@ -78,4 +78,4 @@ ctest --preset linux-gcc
 
 ## License
 
-Distributed under the MIT Software License (X11 license). (See accompanying file LICENSE.)
+Distributed under the MIT Software License (X11 license). (See accompanying file LICENSE.) Bundled third-party components and their licenses are listed in [`THIRD-PARTY-LICENSES.md`](THIRD-PARTY-LICENSES.md).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ optics::compute_reachability_dists<T, Dim, Backend>(
     n_threads = 0);                         // 0 => hardware concurrency
 ```
 
+### Convenience helpers
+
+- `optics::cluster_dbscan(points, min_pts, threshold)` — compute the ordering and cut at a threshold in one call (returns one index list per cluster).
+- `optics::extract_xi(reach_dists, chi, min_pts)` — Xi (steep-area) clusters as point-index lists.
+- `optics::convert_cloud<float>(int_points)` — convert an integer/byte cloud (e.g. `uint8` color data) to a floating-point cloud, since `T` must be `float`/`double`.
+
 ### Visualizing results
 
 The core writes no images; export CSV and render with the bundled script (matplotlib):

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,92 @@
+# Third-Party Licenses
+
+OPTICS-Clustering itself is licensed under the MIT License (see `LICENSE`). It
+bundles the third-party components below. Their licenses are reproduced here;
+the copyright notices are retained in the vendored source files as well.
+
+| Component | Where | License | Scope |
+|-----------|-------|---------|-------|
+| nanoflann | `include/optics/nanoflann.hpp` | BSD 2-Clause | **runtime** (default neighbor-search backend) |
+| doctest   | `test/third_party/doctest.h`   | MIT          | test-only |
+| nanobench | `test/third_party/nanobench.h` | MIT          | test-only (perf harness) |
+
+Only **nanoflann** is part of the library you compile against; doctest and
+nanobench are used solely to build the tests/benchmarks and are not required to
+use OPTICS-Clustering.
+
+---
+
+## nanoflann — BSD 2-Clause License
+
+Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.
+Copyright 2008-2009  David G. Lowe (lowe@cs.ubc.ca). All rights reserved.
+Copyright 2011-2024  Jose Luis Blanco (joseluisblancoc@gmail.com). All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+## doctest — MIT License
+
+Copyright (c) 2016-2023 Viktor Kirilov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## nanobench — MIT License
+
+Copyright (c) 2019-2023 Martin Leitner-Ankerl <martin.ankerl@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmake/opticsConfig.cmake.in
+++ b/cmake/opticsConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/opticsTargets.cmake")
+
+check_required_components(optics)

--- a/docs/ROADMAP-0.9.md
+++ b/docs/ROADMAP-0.9.md
@@ -1,0 +1,120 @@
+# Roadmap to v0.9.0
+
+Status target: a **fast, dependency-free, installable, well-tested** OPTICS release.
+Work happens on branch `release-0.9` (off the `modernize-cpp20` modernization). Task IDs
+below refer to the session task tracker.
+
+## Exit criteria (definition of done for 0.9)
+
+- Tier-0 performance optimizations landed, each with a **measured** before/after improvement
+  and no regressions against the committed baseline.
+- A real test framework (not bare `assert`) with per-case CTest integration, green on
+  MSVC + GCC + Clang (and the Boost-backend job).
+- Performance-regression harness with a committed baseline.
+- Edge cases handled and covered by tests.
+- Installable via CMake (`find_package(optics)` / FetchContent) with versioning + CHANGELOG.
+- Tag `v0.9.0`.
+
+`#23` (faithful ExtractDBSCAN) is **out of scope for 0.9** — deferred.
+
+---
+
+## Foundations — do these first
+
+### Testing framework — decision: **doctest** (#24)
+
+The suites currently live in a hand-rolled `main()` full of `assert()`. Problems: the first
+failure aborts the whole run, there is no per-case reporting or CTest granularity, and
+`assert` is compiled out under `NDEBUG` (we work around it today with `/UNDEBUG`).
+
+**Adopt [doctest](https://github.com/doctest/doctest):** a single vendored header (matches the
+nanoflann/"vendor one header" ethos), the fastest-compiling C++ test framework, with
+`TEST_CASE`/`CHECK`/`SUBCASE` and CTest auto-discovery. It is **test-only** and does **not**
+affect the library's zero-dependency guarantee. Migration is mechanical (`assert` → `CHECK`).
+
+*Alternatives considered:* Catch2 (heavier compile; v3 is a compiled lib), GoogleTest (needs
+build + link, brings a real dependency). doctest is the best fit for a header-only library.
+
+### Performance tracking — decision: **nanobench + committed baseline** (#25)
+
+> "Implement perf tests first to get a baseline to compare to after each essential change."
+
+Vendor [nanobench](https://github.com/martinus/nanobench) (single header, test-only) and add an
+`optics_perf` target that measures, with statistical robustness (median + error %):
+
+- **Hot-path microbenchmarks:** `compute_core_dist`, seed-queue operations, and the full
+  ordering loop at a modest N — these directly quantify the Tier-0 changes.
+- **End-to-end scenarios:** 3D and 16D, float and double, Precompute/OnDemand, 1 vs HW threads,
+  at sizes that run quickly and repeatably.
+
+Emit machine-readable results, **commit a baseline** under `perf/` (with the dev-machine
+hardware noted), and add a tolerance-based compare step. CI runs it **informationally** (runner
+hardware varies, so it is not a gate). This harness must exist **before #12** so each essential
+optimization is measured before/after. (`#12` is marked blocked-by `#25`.)
+
+*Note:* `optics_perf` is for repeatable regression tracking; the existing `optics_benchmark`
+stays for ad-hoc large-scale (1e6–1e7) exploration (#16).
+
+---
+
+## Tier 0 — Performance arc (measure each against the baseline)
+
+1. **#12 Optimize `compute_core_dist`** *(start here, per request).* Drop the per-call
+   `vector<size_t>` copy; fill a reused `thread_local` scratch of squared distances and return
+   the sqrt of the MinPts-th smallest. Re-run perf, record the delta.
+2. **#13 Fuse neighbor-distance computation** — distances are computed twice today
+   (`compute_core_dist` + `update`); compute once and reuse.
+3. **#14 Replace the `std::set` seed queue with a lazy-deletion heap** — removes per-insert node
+   allocation and improves cache behavior in the sequential ordering loop. Likely the largest
+   single win after neighbor queries. Re-verify `chi_*` and the neighbor-mode parity test.
+4. **#15 CSR-flatten precomputed neighbors** — one flat index buffer + offsets instead of
+   `vector<vector<size_t>>`; cuts millions of allocations and memory at 1e6–1e7 points.
+5. **#16 Benchmark at 1e6–1e7 scale** — validate the optimizations and memory at the real
+   target sizes; record numbers.
+
+## Tier 1 — Release readiness
+
+6. **#17 CMake install/export + package config** — install headers (incl. vendored nanoflann),
+   export `optics::optics`, generate config + version files for `find_package`/FetchContent.
+7. **#18 Versioning** — `project(... VERSION 0.9.0)`, `OPTICS_VERSION` macro, `CHANGELOG.md`.
+8. **#19 API surface cleanup** — move internal helpers (`bounding_box`, `hypercuboid_volume`,
+   `SDA`, `pop_from_set`, …) into `optics::detail`; freeze the public API.
+9. **#20 Convenience entry points + byte/int ergonomics** — `extract_dbscan`/`extract_xi`
+   wrappers, a one-call cluster→labels helper, and a documented conversion path for `uint8`
+   color data (since `T` must be float/double).
+
+## Tier 2 — Correctness & confidence (written in doctest)
+
+10. **#21 Brute-force O(n²) reference test** — assert the pipeline matches a naive OPTICS on
+    small clouds (the `chi_*` tests only pin current behavior, not paper-correctness).
+11. **#22 Edge-case handling + tests** — `< min_pts` points, all-identical points (replace the
+    `eps = 1.0` fallback hack), duplicates, empty input, NaN/inf; plus float-vs-double parity
+    and seed tie-break determinism.
+
+## Out of scope for 0.9 (parked)
+
+- **#23** faithful ExtractDBSCAN (store `core_dist`, paper-accurate threshold extractor).
+- ASan/UBSan CI job, warnings-as-errors, clang-format.
+- Doxygen API docs.
+- Approximate-NN option for the expensive 16-D regime.
+
+---
+
+## Sequencing
+
+```
+Foundations:  #24 doctest        ┐ (can run in parallel)
+              #25 perf baseline   ┘  ← must precede #12
+Tier 0:       #12 → measure → #13 → #14 → #15 → measure each → #16 (at scale)
+Tier 1:       #17 → #18 → #19 → #20
+Tier 2:       #21, #22  (in doctest)
+Release:      verify checklist → tag v0.9.0
+```
+
+## Release checklist
+
+- [ ] doctest suite + Boost-backend test green on MSVC, GCC, Clang.
+- [ ] Perf baseline shows net improvement; no regressions beyond tolerance.
+- [ ] `find_package(optics)` works from a throwaway consumer project.
+- [ ] Edge-case tests pass; no `eps = 1.0` hack remaining.
+- [ ] `CHANGELOG.md` updated; version bumped; tag `v0.9.0`.

--- a/docs/ROADMAP-0.9.md
+++ b/docs/ROADMAP-0.9.md
@@ -82,12 +82,17 @@ stays for ad-hoc large-scale (1e6–1e7) exploration (#16).
 9. **#20 Convenience entry points + byte/int ergonomics** — `extract_dbscan`/`extract_xi`
    wrappers, a one-call cluster→labels helper, and a documented conversion path for `uint8`
    color data (since `T` must be float/double).
+10. **#26 License compliance** — nanoflann is **BSD-2-Clause** (its header is preserved in
+    `nanoflann.hpp`, satisfying source redistribution); our own license **stays MIT**. Add a
+    `THIRD-PARTY-LICENSES` file enumerating nanoflann (BSD-2-Clause) plus the test-only deps
+    doctest + nanobench (MIT), and reference it from `README`/`LICENSE`. This also covers the
+    BSD binary-distribution attribution clause for downstream consumers.
 
 ## Tier 2 — Correctness & confidence (written in doctest)
 
-10. **#21 Brute-force O(n²) reference test** — assert the pipeline matches a naive OPTICS on
+11. **#21 Brute-force O(n²) reference test** — assert the pipeline matches a naive OPTICS on
     small clouds (the `chi_*` tests only pin current behavior, not paper-correctness).
-11. **#22 Edge-case handling + tests** — `< min_pts` points, all-identical points (replace the
+12. **#22 Edge-case handling + tests** — `< min_pts` points, all-identical points (replace the
     `eps = 1.0` fallback hack), duplicates, empty input, NaN/inf; plus float-vs-double parity
     and seed tie-break determinism.
 
@@ -116,5 +121,6 @@ Release:      verify checklist → tag v0.9.0
 - [ ] doctest suite + Boost-backend test green on MSVC, GCC, Clang.
 - [ ] Perf baseline shows net improvement; no regressions beyond tolerance.
 - [ ] `find_package(optics)` works from a throwaway consumer project.
+- [ ] `THIRD-PARTY-LICENSES` present (nanoflann BSD-2-Clause + test-only MIT deps); README references it.
 - [ ] Edge-case tests pass; no `eps = 1.0` hack remaining.
 - [ ] `CHANGELOG.md` updated; version bumped; tag `v0.9.0`.

--- a/include/optics/optics.hpp
+++ b/include/optics/optics.hpp
@@ -7,6 +7,7 @@
 
 #include "backend.hpp"
 #include "tree.hpp"
+#include "version.hpp"
 #include "detail/math.hpp"
 #include "detail/thread_pool.hpp"
 

--- a/include/optics/optics.hpp
+++ b/include/optics/optics.hpp
@@ -16,7 +16,7 @@
 #include <cmath>
 #include <cstddef>
 #include <optional>
-#include <set>
+#include <queue>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -84,40 +84,17 @@ std::optional<double> compute_core_dist( const Point<T, Dim>& point,
 }
 
 
-inline void erase_idx_from_set( const reachability_dist& d, std::set<reachability_dist>& seeds ) {
-	const auto erased = seeds.erase( d );
-	assert( erased == 1 );
-	(void)erased;
-}
+// Min-heap order for the seed priority queue: smallest reachability first, ties
+// broken by smallest point index (matching reachability_dist's operator<). The
+// queue uses lazy deletion -- "decrease-key" pushes a new (smaller) entry and
+// the authoritative value lives in the reachability[] array; stale pops are
+// skipped. This reproduces the std::set pop order exactly while avoiding a node
+// allocation per insert.
+struct seed_min_heap_cmp {
+	bool operator()( const reachability_dist& a, const reachability_dist& b ) const { return b < a; }
+};
 
-template <typename T>
-T pop_from_set( std::set<T>& set ) {
-	T element = *set.begin();
-	set.erase( set.begin() );
-	return element;
-}
-
-
-// Relax the reachability distances of the unprocessed neighbors of a core
-// object and (re-)insert them into the seed priority queue.
-template <typename T, std::size_t Dim>
-void update( const Point<T, Dim>& point, const std::vector<Point<T, Dim>>& points,
-			 const std::vector<std::size_t>& neighbor_indices, double core_dist,
-			 const std::vector<char>& processed, std::vector<double>& reachability,
-			 std::set<reachability_dist>& seeds ) {
-	for ( const auto& o : neighbor_indices ) {
-		if ( processed[o] ) { continue; }
-		const double new_reachability_dist = std::max( core_dist, detail::dist( point, points[o] ) );
-		if ( reachability[o] < 0.0 ) {
-			reachability[o] = new_reachability_dist;
-			seeds.insert( reachability_dist( o, new_reachability_dist ) );
-		} else if ( new_reachability_dist < reachability[o] ) {
-			erase_idx_from_set( reachability_dist( o, reachability[o] ), seeds );
-			reachability[o] = new_reachability_dist;
-			seeds.insert( reachability_dist( o, new_reachability_dist ) );
-		}
-	}
-}
+using seed_queue = std::priority_queue<reachability_dist, std::vector<reachability_dist>, seed_min_heap_cmp>;
 
 
 //=== Epsilon estimation =====================================================
@@ -214,27 +191,39 @@ std::vector<reachability_dist> compute_reachability_dists(
 		return ondemand_buf;
 	};
 
+	// Reused across points; drained to empty whenever an expansion finishes.
+	seed_queue seeds;
+	const auto relax_neighbors = [&]( std::size_t idx, const std::vector<std::size_t>& nbrs, double core_dist ) {
+		for ( const std::size_t o : nbrs ) {
+			if ( processed[o] ) { continue; }
+			const double new_rd = std::max( core_dist, detail::dist( points[idx], points[o] ) );
+			if ( reachability[o] < 0.0 || new_rd < reachability[o] ) {
+				reachability[o] = new_rd;  // authoritative; the prior heap entry becomes stale
+				seeds.push( reachability_dist( o, new_rd ) );
+			}
+		}
+	};
+
 	for ( std::size_t point_idx = 0; point_idx < n; point_idx++ ) {
 		if ( processed[point_idx] ) { continue; }
 		processed[point_idx] = 1;
 		ordered_list.push_back( point_idx );
-		std::set<reachability_dist> seeds;
 
 		const auto& neighbor_indices = neighbors_of( point_idx );
 		const auto core_dist = compute_core_dist( points[point_idx], points, neighbor_indices, min_pts );
-		if ( !core_dist.has_value() ) { continue; }
+		if ( core_dist.has_value() ) { relax_neighbors( point_idx, neighbor_indices, *core_dist ); }
 
-		update( points[point_idx], points, neighbor_indices, *core_dist, processed, reachability, seeds );
 		while ( !seeds.empty() ) {
-			const reachability_dist s = pop_from_set( seeds );
-			assert( !processed[s.point_index] );
+			const reachability_dist s = seeds.top();
+			seeds.pop();
+			// Lazy deletion: skip entries already processed or superseded by a smaller push.
+			if ( processed[s.point_index] || s.reach_dist != reachability[s.point_index] ) { continue; }
 			processed[s.point_index] = 1;
 			ordered_list.push_back( s.point_index );
 
 			const auto& s_neighbor_indices = neighbors_of( s.point_index );
 			const auto s_core_dist = compute_core_dist( points[s.point_index], points, s_neighbor_indices, min_pts );
-			if ( !s_core_dist.has_value() ) { continue; }
-			update( points[s.point_index], points, s_neighbor_indices, *s_core_dist, processed, reachability, seeds );
+			if ( s_core_dist.has_value() ) { relax_neighbors( s.point_index, s_neighbor_indices, *s_core_dist ); }
 		}
 	}
 	assert( ordered_list.size() == n );

--- a/include/optics/optics.hpp
+++ b/include/optics/optics.hpp
@@ -68,12 +68,19 @@ std::optional<double> compute_core_dist( const Point<T, Dim>& point,
 										 std::size_t min_pts ) {
 	if ( neighbor_indices.size() < min_pts ) { return std::nullopt; }
 
-	std::vector<std::size_t> idxs( neighbor_indices );
-	std::nth_element( idxs.begin(), idxs.begin() + ( min_pts - 1 ), idxs.end(),
-					  [&points, &point]( std::size_t a, std::size_t b ) {
-						  return detail::square_dist( point, points[a] ) < detail::square_dist( point, points[b] );
-					  } );
-	return detail::dist( point, points[idxs[min_pts - 1]] );
+	// Compute each neighbor's squared distance exactly once into a reused buffer,
+	// then nth_element on the distances directly. Avoids the per-call index-vector
+	// copy and the repeated distance computations a key-comparator would incur.
+	// thread_local: the buffer is reused across calls (no allocation after warmup)
+	// and stays correct if core_dist is ever invoked from multiple threads.
+	thread_local std::vector<double> sq_dists;
+	sq_dists.clear();
+	sq_dists.reserve( neighbor_indices.size() );
+	for ( const std::size_t idx : neighbor_indices ) {
+		sq_dists.push_back( detail::square_dist( point, points[idx] ) );
+	}
+	std::nth_element( sq_dists.begin(), sq_dists.begin() + ( min_pts - 1 ), sq_dists.end() );
+	return std::sqrt( sq_dists[min_pts - 1] );
 }
 
 

--- a/include/optics/optics.hpp
+++ b/include/optics/optics.hpp
@@ -141,11 +141,25 @@ double epsilon_estimation( const std::vector<Point<T, dimension>>& points, std::
 	static_assert( dimension >= 1, "epsilon_estimation: dimension must be >= 1" );
 	if ( points.size() <= 1 ) { return 0.0; }
 
-	const double d = static_cast<double>( dimension );
 	const auto space = detail::bounding_box( points );
-	const double space_volume = detail::hypercuboid_volume( space.first, space.second );
+	// Use only dimensions with non-zero extent, so degenerate inputs (collinear,
+	// planar, or all-identical) yield a sensible scale instead of a zero volume.
+	double effective_volume = 1.0;
+	std::size_t d_eff = 0;
+	for ( std::size_t i = 0; i < dimension; ++i ) {
+		const double extent = std::abs( static_cast<double>( space.second[i] - space.first[i] ) );
+		if ( extent > 0.0 ) {
+			effective_volume *= extent;
+			++d_eff;
+		}
+	}
+	// d_eff == 0 means every coordinate is identical across all points: there is no
+	// spatial scale, every pairwise distance is 0, and any positive radius groups
+	// them identically, so the concrete value is immaterial.
+	if ( d_eff == 0 ) { return 1.0; }
 
-	const double space_per_minpts_points = ( space_volume / static_cast<double>( points.size() ) ) * static_cast<double>( min_pts );
+	const double d = static_cast<double>( d_eff );
+	const double space_per_minpts_points = ( effective_volume / static_cast<double>( points.size() ) ) * static_cast<double>( min_pts );
 	const double n_dim_unit_ball_vol = std::sqrt( std::pow( detail::pi, d ) ) / std::tgamma( d / 2.0 + 1.0 );
 	return std::pow( space_per_minpts_points / n_dim_unit_ball_vol, 1.0 / d );
 }
@@ -173,7 +187,9 @@ std::vector<reachability_dist> compute_reachability_dists(
 
 	double eps = epsilon;
 	if ( eps <= 0.0 ) { eps = epsilon_estimation( points, min_pts ); }
-	if ( eps <= 0.0 ) { eps = 1.0; }  // degenerate input (all points identical): any positive radius works
+	// epsilon_estimation returns a positive scale for any input with >= 2 points,
+	// using only the non-degenerate dimensions (so collinear/planar/identical
+	// inputs no longer collapse to a zero radius).
 	const T eps_t = static_cast<T>( eps );
 
 	const Backend backend( points );

--- a/include/optics/optics.hpp
+++ b/include/optics/optics.hpp
@@ -508,4 +508,40 @@ std::vector<std::vector<std::array<T, dimension>>> get_cluster_points(
 	return result;
 }
 
+
+//=== Convenience entry points ===============================================
+
+// Convert an integer/byte cloud (e.g. uint8 color data) to a float/double cloud,
+// since the algorithm requires a floating-point coordinate type:
+//   auto cloud = optics::convert_cloud<float>( uint8_points );
+template <typename Out, typename In, std::size_t Dim>
+std::vector<std::array<Out, Dim>> convert_cloud( const std::vector<std::array<In, Dim>>& in ) {
+	std::vector<std::array<Out, Dim>> out;
+	out.reserve( in.size() );
+	for ( const auto& p : in ) {
+		std::array<Out, Dim> q;
+		for ( std::size_t k = 0; k < Dim; ++k ) { q[k] = static_cast<Out>( p[k] ); }
+		out.push_back( q );
+	}
+	return out;
+}
+
+// One-call DBSCAN-style clustering: compute the ordering and cut at a threshold.
+// Returns one index list per cluster (noise points become singletons).
+template <class T, std::size_t Dim, class Backend = NanoflannBackend<T, Dim>>
+std::vector<std::vector<std::size_t>> cluster_dbscan(
+	const std::vector<std::array<T, Dim>>& points, std::size_t min_pts, double threshold,
+	double epsilon = -1.0, NeighborMode mode = NeighborMode::Precompute, unsigned n_threads = 0 ) {
+	const auto reach = compute_reachability_dists<T, Dim, Backend>( points, min_pts, epsilon, mode, n_threads );
+	return get_cluster_indices( reach, threshold );
+}
+
+// Xi (steep-area) clusters as point-index lists, in one call from a cluster-ordering.
+inline std::vector<std::vector<std::size_t>> extract_xi(
+	const std::vector<reachability_dist>& reach_dists, double chi, std::size_t min_pts,
+	double steep_area_min_diff = 0.0 ) {
+	const auto flat = get_chi_clusters_flat( reach_dists, chi, min_pts, steep_area_min_diff );
+	return get_cluster_indices( reach_dists, flat );
+}
+
 }  // namespace optics

--- a/include/optics/optics.hpp
+++ b/include/optics/optics.hpp
@@ -58,7 +58,9 @@ inline std::ostringstream& operator<<( std::ostringstream& stream, const reachab
 }
 
 
-//=== Core OPTICS primitives =================================================
+//=== Core OPTICS primitives (internal) ======================================
+
+namespace detail {
 
 // core-distance of a point: nullopt if it has fewer than min_pts neighbors
 // (incl. itself), else the distance to its min_pts-th nearest neighbor.
@@ -97,8 +99,12 @@ struct seed_min_heap_cmp {
 
 using seed_queue = std::priority_queue<reachability_dist, std::vector<reachability_dist>, seed_min_heap_cmp>;
 
+}  // namespace detail
+
 
 //=== Epsilon estimation =====================================================
+
+namespace detail {
 
 template <typename T, std::size_t dimension>
 std::pair<Point<T, dimension>, Point<T, dimension>> bounding_box( const std::vector<Point<T, dimension>>& points ) {
@@ -125,6 +131,8 @@ double hypercuboid_volume( const Point<T, dimension>& bl, const Point<T, dimensi
 	return volume;
 }
 
+}  // namespace detail
+
 // Heuristic generating distance: the expected MinPts-nearest-neighbor distance
 // assuming a uniform point distribution over the data's bounding box.
 template <typename T, std::size_t dimension>
@@ -134,8 +142,8 @@ double epsilon_estimation( const std::vector<Point<T, dimension>>& points, std::
 	if ( points.size() <= 1 ) { return 0.0; }
 
 	const double d = static_cast<double>( dimension );
-	const auto space = bounding_box( points );
-	const double space_volume = hypercuboid_volume( space.first, space.second );
+	const auto space = detail::bounding_box( points );
+	const double space_volume = detail::hypercuboid_volume( space.first, space.second );
 
 	const double space_per_minpts_points = ( space_volume / static_cast<double>( points.size() ) ) * static_cast<double>( min_pts );
 	const double n_dim_unit_ball_vol = std::sqrt( std::pow( detail::pi, d ) ) / std::tgamma( d / 2.0 + 1.0 );
@@ -193,7 +201,7 @@ std::vector<reachability_dist> compute_reachability_dists(
 	};
 
 	// Reused across points; drained to empty whenever an expansion finishes.
-	seed_queue seeds;
+	detail::seed_queue seeds;
 	const auto relax_neighbors = [&]( std::size_t idx, const std::vector<std::size_t>& nbrs, double core_dist ) {
 		for ( const std::size_t o : nbrs ) {
 			if ( processed[o] ) { continue; }
@@ -211,7 +219,7 @@ std::vector<reachability_dist> compute_reachability_dists(
 		ordered_list.push_back( point_idx );
 
 		const auto& neighbor_indices = neighbors_of( point_idx );
-		const auto core_dist = compute_core_dist( points[point_idx], points, neighbor_indices, min_pts );
+		const auto core_dist = detail::compute_core_dist( points[point_idx], points, neighbor_indices, min_pts );
 		if ( core_dist.has_value() ) { relax_neighbors( point_idx, neighbor_indices, *core_dist ); }
 
 		while ( !seeds.empty() ) {
@@ -223,7 +231,7 @@ std::vector<reachability_dist> compute_reachability_dists(
 			ordered_list.push_back( s.point_index );
 
 			const auto& s_neighbor_indices = neighbors_of( s.point_index );
-			const auto s_core_dist = compute_core_dist( points[s.point_index], points, s_neighbor_indices, min_pts );
+			const auto s_core_dist = detail::compute_core_dist( points[s.point_index], points, s_neighbor_indices, min_pts );
 			if ( s_core_dist.has_value() ) { relax_neighbors( s.point_index, s_neighbor_indices, *s_core_dist ); }
 		}
 	}
@@ -274,17 +282,21 @@ std::vector<std::vector<std::array<T, dimension>>> get_cluster_points(
 
 //=== Xi / steep-area cluster extraction =====================================
 
+namespace detail {
+// A steep-down area (start/end index + maximum-in-between value); internal to
+// the Xi extraction.
 struct SDA {
 	SDA( std::size_t begin_idx_, std::size_t end_idx_, double mib_ ) : begin_idx( begin_idx_ ), end_idx( end_idx_ ), mib( mib_ ) {}
 	std::size_t begin_idx;
 	std::size_t end_idx;
 	double mib;
 };
+}  // namespace detail
 
 
 inline std::vector<chi_cluster_indices> get_chi_clusters_flat( const std::vector<reachability_dist>& reach_dists_, const double chi, std::size_t min_pts, double steep_area_min_diff = 0.0 ) {
 	std::vector<std::pair<std::size_t, std::size_t>> clusters;
-	std::vector<SDA> SDAs;
+	std::vector<detail::SDA> SDAs;
 	const std::size_t n_reachdists = reach_dists_.size();
 	double mib( 0 );
 	double max_reach( 0.0 );
@@ -308,7 +320,7 @@ inline std::vector<chi_cluster_indices> get_chi_clusters_flat( const std::vector
 		return get_reach_dist( idx + 1 ) * ( 1 - chi ) >= get_reach_dist( idx );
 	};
 	const auto filter_sdas = [&chi, &steep_area_min_diff, &SDAs, &mib, &get_reach_dist]() {
-		std::erase_if( SDAs, [&mib, &chi, &steep_area_min_diff, &get_reach_dist]( const SDA& sda ) -> bool {
+		std::erase_if( SDAs, [&mib, &chi, &steep_area_min_diff, &get_reach_dist]( const detail::SDA& sda ) -> bool {
 			const double f = std::max( chi, steep_area_min_diff );
 			return !( mib <= get_reach_dist( sda.begin_idx ) * ( 1 - f ) );
 		} );
@@ -340,7 +352,7 @@ inline std::vector<chi_cluster_indices> get_chi_clusters_flat( const std::vector
 		}
 		return std::max( n_reachdists - 2, last_su_idx );
 	};
-	const auto cluster_borders = [&get_reach_dist, &n_reachdists, &chi]( const SDA& sda, std::size_t sua_begin_idx, std::size_t sua_end_idx ) -> std::pair<std::size_t, std::size_t> {
+	const auto cluster_borders = [&get_reach_dist, &n_reachdists, &chi]( const detail::SDA& sda, std::size_t sua_begin_idx, std::size_t sua_end_idx ) -> std::pair<std::size_t, std::size_t> {
 		double start_reach = get_reach_dist( sda.begin_idx );
 		double end_reach = get_reach_dist( std::min( sua_end_idx + 1, n_reachdists - 1 ) );
 		if ( detail::in_range( start_reach, end_reach, start_reach * chi ) ) {
@@ -363,7 +375,7 @@ inline std::vector<chi_cluster_indices> get_chi_clusters_flat( const std::vector
 		assert( false );
 		return { 0, 0 };
 	};
-	const auto valid_combination = [&chi, &steep_area_min_diff, &min_pts, &get_reach_dist]( const SDA& sda, std::size_t sua_begin_idx, std::size_t sua_end_idx ) -> bool {
+	const auto valid_combination = [&chi, &steep_area_min_diff, &min_pts, &get_reach_dist]( const detail::SDA& sda, std::size_t sua_begin_idx, std::size_t sua_end_idx ) -> bool {
 		const double f = std::max( chi, steep_area_min_diff );
 		if ( sda.mib > get_reach_dist( sua_end_idx + 1 ) * ( 1 - f ) ) { return false; }
 
@@ -387,7 +399,7 @@ inline std::vector<chi_cluster_indices> get_chi_clusters_flat( const std::vector
 			if ( reach_i * ( 1.0 - steep_area_min_diff ) < get_reach_dist( sda_end_idx + 1 ) ) {
 				continue;
 			}
-			SDAs.push_back( SDA( idx, sda_end_idx, 0.0 ) );
+			SDAs.push_back( detail::SDA( idx, sda_end_idx, 0.0 ) );
 			idx = sda_end_idx;
 			if ( idx < n_reachdists - 1 ) { mib = get_reach_dist( idx + 1 ); }
 			continue;

--- a/include/optics/version.hpp
+++ b/include/optics/version.hpp
@@ -1,0 +1,19 @@
+// Copyright Ingo Proff 2016.
+// https://github.com/J-D-3/OPTICS-Clustering
+// Distributed under the MIT Software License (X11 license).
+// (See accompanying file LICENSE)
+
+#pragma once
+
+// Library version. Keep in sync with the project() VERSION in CMakeLists.txt.
+#define OPTICS_VERSION_MAJOR 0
+#define OPTICS_VERSION_MINOR 9
+#define OPTICS_VERSION_PATCH 0
+#define OPTICS_VERSION_STRING "0.9.0"
+
+// Single integer for easy comparisons: major*10000 + minor*100 + patch.
+#define OPTICS_VERSION ( OPTICS_VERSION_MAJOR * 10000 + OPTICS_VERSION_MINOR * 100 + OPTICS_VERSION_PATCH )
+
+namespace optics {
+inline constexpr const char* version() { return OPTICS_VERSION_STRING; }
+}  // namespace optics

--- a/perf/README.md
+++ b/perf/README.md
@@ -32,3 +32,21 @@ days-old `baseline.csv` and trust small deltas. Instead, for each essential chan
 Refresh `baseline.csv` after each landed Tier-0 change so it tracks the current best.
 CI may run `optics_perf` informationally, but timings are **not** a gate (runner hardware
 varies).
+
+## Large-scale validation (`optics_scale`)
+
+`optics_scale [n]` times the 3D color-space-style workload (uniform cloud, min_pts=16) at
+1e6–1e7 points. Baselines on a 22-thread desktop (Release), committed-code path:
+
+| workload      | Precompute (xHW) | OnDemand (x1) |
+|---------------|------------------|---------------|
+| 3D float  1e6 | ~5.8 s           | ~7.8 s        |
+| 3D double 1e6 | ~6.7 s           | ~9.3 s        |
+| 3D float  1e7 | ~44.0 s          | ~52.0 s       |
+| 3D double 1e7 | ~45.7 s          | ~55.7 s       |
+
+Both modes order the full cloud; Precompute did not OOM at 1e7 on the desktop. Note the modest
+Precompute-vs-OnDemand gap at 1e7: the sequential ordering loop is a large fraction at this
+scale, so parallelizing only the query phase is Amdahl-limited. Confirms the Tier-0 finding that
+OPTICS is **query-bound** — future speedups live in the query path (backend, approximate-NN),
+not the surrounding bookkeeping.

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,34 @@
+# Performance tracking
+
+`optics_perf` (built from `test/Benchmark/perf.cpp`, nanobench) measures the hot paths and a
+few end-to-end ordering scenarios, and writes `optics_perf.csv`. Use it to quantify the impact
+of the Tier-0 performance work (see `docs/ROADMAP-0.9.md`).
+
+## Running
+
+```sh
+cmake --build build --config Release --target optics_perf
+./build/test/Release/optics_perf      # writes optics_perf.csv in the working dir
+```
+
+## `baseline.csv`
+
+Committed reference, captured **before** task #12 (`compute_core_dist` optimization).
+
+- Machine: 22-thread desktop (Windows, MSVC 19.44, Release).
+- Headline metric for #12: **`core_dist 3D double (30k)`** (per-call ns, `elapsed` column ÷ batch).
+
+## How to compare (important)
+
+This is a noisy multi-core desktop: run-to-run variation on the microbenchmarks can reach
+~30%, larger than the intra-run `error %`. So **do not** compare a fresh run against a
+days-old `baseline.csv` and trust small deltas. Instead, for each essential change:
+
+1. Build + run `optics_perf` on the parent commit, save the CSV.
+2. Build + run on the change, save the CSV.
+3. Compare the two **back-to-back** runs; treat only changes clearly above the run-to-run
+   noise (rule of thumb: > ~15–20% on the microbenchmarks) as signal.
+
+Refresh `baseline.csv` after each landed Tier-0 change so it tracks the current best.
+CI may run `optics_perf` informationally, but timings are **not** a gate (runner hardware
+varies).

--- a/perf/baseline.csv
+++ b/perf/baseline.csv
@@ -1,9 +1,9 @@
 "title";"name";"unit";"batch";"elapsed";"error %";"instructions";"branches";"branch misses";"total"
-"OPTICS perf (hw=22)";"core_dist 3D double (30k)";"op";30000;0.015535275;0.0431415321680349;0;0;0;1.8664738
-"OPTICS perf (hw=22)";"core_dist 3D float  (30k)";"op";30000;0.016843325;0.0726042233327239;0;0;0;2.0339285
-"OPTICS perf (hw=22)";"core_dist 16D double (8k)";"op";8000;2.27790697674419e-05;0.0977864948164751;0;0;0;0.013659
-"OPTICS perf (hw=22)";"ordering 3D double 30k precompute x1";"op";1;0.107956875;0.0128893025166749;0;0;0;3.6574613
-"OPTICS perf (hw=22)";"ordering 3D double 30k precompute xHW";"op";1;0.076417475;0.0142947684180488;0;0;0;2.5965483
-"OPTICS perf (hw=22)";"ordering 3D double 30k ondemand x1";"op";1;0.0944998333333333;0.0122368402730295;0;0;0;3.2004756
-"OPTICS perf (hw=22)";"ordering 3D float 30k precompute xHW";"op";1;0.0704902333333333;0.0178650439216675;0;0;0;2.4107667
-"OPTICS perf (hw=22)";"ordering 16D double 8k precompute xHW";"op";1;0.0833785;0.0178892762007233;0;0;0;2.8620778
+"OPTICS perf (hw=22)";"core_dist 3D double (30k)";"op";30000;0.00678103636363636;0.084575371048241;0;0;0;0.8498501
+"OPTICS perf (hw=22)";"core_dist 3D float  (30k)";"op";30000;0.007363225;0.0807451820757071;0;0;0;0.883464
+"OPTICS perf (hw=22)";"core_dist 16D double (8k)";"op";8000;1.88280701754386e-05;0.0229668476031448;0;0;0;0.0151008
+"OPTICS perf (hw=22)";"ordering 3D double 30k precompute x1";"op";1;0.1143319;0.0871268620054223;0;0;0;3.9908875
+"OPTICS perf (hw=22)";"ordering 3D double 30k precompute xHW";"op";1;0.0745885333333333;0.0560864330553954;0;0;0;2.636881
+"OPTICS perf (hw=22)";"ordering 3D double 30k ondemand x1";"op";1;0.0904864333333333;0.0575309047900282;0;0;0;3.1757389
+"OPTICS perf (hw=22)";"ordering 3D float 30k precompute xHW";"op";1;0.0683571;0.0428741317686109;0;0;0;2.3307245
+"OPTICS perf (hw=22)";"ordering 16D double 8k precompute xHW";"op";1;0.0854133666666667;0.0192870161214393;0;0;0;2.9192573

--- a/perf/baseline.csv
+++ b/perf/baseline.csv
@@ -1,0 +1,9 @@
+"title";"name";"unit";"batch";"elapsed";"error %";"instructions";"branches";"branch misses";"total"
+"OPTICS perf (hw=22)";"core_dist 3D double (30k)";"op";30000;0.015535275;0.0431415321680349;0;0;0;1.8664738
+"OPTICS perf (hw=22)";"core_dist 3D float  (30k)";"op";30000;0.016843325;0.0726042233327239;0;0;0;2.0339285
+"OPTICS perf (hw=22)";"core_dist 16D double (8k)";"op";8000;2.27790697674419e-05;0.0977864948164751;0;0;0;0.013659
+"OPTICS perf (hw=22)";"ordering 3D double 30k precompute x1";"op";1;0.107956875;0.0128893025166749;0;0;0;3.6574613
+"OPTICS perf (hw=22)";"ordering 3D double 30k precompute xHW";"op";1;0.076417475;0.0142947684180488;0;0;0;2.5965483
+"OPTICS perf (hw=22)";"ordering 3D double 30k ondemand x1";"op";1;0.0944998333333333;0.0122368402730295;0;0;0;3.2004756
+"OPTICS perf (hw=22)";"ordering 3D float 30k precompute xHW";"op";1;0.0704902333333333;0.0178650439216675;0;0;0;2.4107667
+"OPTICS perf (hw=22)";"ordering 16D double 8k precompute xHW";"op";1;0.0833785;0.0178892762007233;0;0;0;2.8620778

--- a/perf/baseline.csv
+++ b/perf/baseline.csv
@@ -1,9 +1,9 @@
 "title";"name";"unit";"batch";"elapsed";"error %";"instructions";"branches";"branch misses";"total"
-"OPTICS perf (hw=22)";"core_dist 3D double (30k)";"op";30000;0.00678103636363636;0.084575371048241;0;0;0;0.8498501
-"OPTICS perf (hw=22)";"core_dist 3D float  (30k)";"op";30000;0.007363225;0.0807451820757071;0;0;0;0.883464
-"OPTICS perf (hw=22)";"core_dist 16D double (8k)";"op";8000;1.88280701754386e-05;0.0229668476031448;0;0;0;0.0151008
-"OPTICS perf (hw=22)";"ordering 3D double 30k precompute x1";"op";1;0.1143319;0.0871268620054223;0;0;0;3.9908875
-"OPTICS perf (hw=22)";"ordering 3D double 30k precompute xHW";"op";1;0.0745885333333333;0.0560864330553954;0;0;0;2.636881
-"OPTICS perf (hw=22)";"ordering 3D double 30k ondemand x1";"op";1;0.0904864333333333;0.0575309047900282;0;0;0;3.1757389
-"OPTICS perf (hw=22)";"ordering 3D float 30k precompute xHW";"op";1;0.0683571;0.0428741317686109;0;0;0;2.3307245
-"OPTICS perf (hw=22)";"ordering 16D double 8k precompute xHW";"op";1;0.0854133666666667;0.0192870161214393;0;0;0;2.9192573
+"OPTICS perf (hw=22)";"core_dist 3D double (30k)";"op";30000;0.008246625;0.00932570538666851;0;0;0;0.977403
+"OPTICS perf (hw=22)";"core_dist 3D float  (30k)";"op";30000;0.00850875833333333;0.0216928065723631;0;0;0;1.0364392
+"OPTICS perf (hw=22)";"core_dist 16D double (8k)";"op";8000;3.85392857142857e-05;0.0614261628218166;0;0;0;0.012375
+"OPTICS perf (hw=22)";"ordering 3D double 30k precompute x1";"op";1;0.129211566666667;0.0339616390825985;0;0;0;4.7378467
+"OPTICS perf (hw=22)";"ordering 3D double 30k precompute xHW";"op";1;0.0714524333333333;0.0618996830014152;0;0;0;3.0279888
+"OPTICS perf (hw=22)";"ordering 3D double 30k ondemand x1";"op";1;0.0975381666666667;0.0360874094353638;0;0;0;3.3894675
+"OPTICS perf (hw=22)";"ordering 3D float 30k precompute xHW";"op";1;0.0689805;0.0135712808036281;0;0;0;2.3501595
+"OPTICS perf (hw=22)";"ordering 16D double 8k precompute xHW";"op";1;0.111943566666667;0.0755331577428996;0;0;0;3.7781464

--- a/test/Benchmark/perf.cpp
+++ b/test/Benchmark/perf.cpp
@@ -1,0 +1,92 @@
+// Copyright Ingo Proff 2016.
+// https://github.com/J-D-3/OPTICS-Clustering
+// Distributed under the MIT Software License (X11 license).
+// (See accompanying file LICENSE)
+
+// Performance-regression harness (nanobench). Measures the hot paths and a few
+// end-to-end scenarios with statistically stable medians, and renders a CSV.
+// Build in a Release config. Re-run before/after each essential change and
+// compare against perf/baseline.csv (see docs/ROADMAP-0.9.md).
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include <nanobench.h>
+
+#include <optics/optics.hpp>
+#include <optics/testdata.hpp>
+
+#include <array>
+#include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+template <class T, std::size_t Dim>
+std::vector<std::vector<std::size_t>> precompute_neighbors(
+	const std::vector<std::array<T, Dim>>& points, const optics::NanoflannBackend<T, Dim>& backend, T eps ) {
+	std::vector<std::vector<std::size_t>> nbrs( points.size() );
+	for ( std::size_t i = 0; i < points.size(); ++i ) { backend.radius_search( points[i], eps, nbrs[i] ); }
+	return nbrs;
+}
+
+// Microbenchmark: one full sweep of compute_core_dist over every point's
+// neighbor list. batch(n) normalizes the reported time to per-call.
+template <class T, std::size_t Dim>
+void bench_core_dist( ankerl::nanobench::Bench& bench, const std::string& name, std::size_t n_points, std::size_t min_pts ) {
+	const auto points = optics::testdata::uniform_noise<T, Dim>( n_points, 0.0, 1000.0 );
+	const optics::NanoflannBackend<T, Dim> backend( points );
+	const T eps = static_cast<T>( optics::epsilon_estimation( points, min_pts ) );
+	const auto nbrs = precompute_neighbors( points, backend, eps );
+
+	bench.batch( points.size() ).run( name, [&] {
+		double acc = 0.0;
+		for ( std::size_t i = 0; i < points.size(); ++i ) {
+			acc += optics::compute_core_dist( points[i], points, nbrs[i], min_pts ).value_or( 0.0 );
+		}
+		ankerl::nanobench::doNotOptimizeAway( acc );
+	} );
+}
+
+// End-to-end ordering benchmark.
+template <class T, std::size_t Dim>
+void bench_ordering( ankerl::nanobench::Bench& bench, const std::string& name, std::size_t n_points,
+					 std::size_t min_pts, optics::NeighborMode mode, unsigned threads ) {
+	const auto points = optics::testdata::uniform_noise<T, Dim>( n_points, 0.0, 1000.0 );
+	bench.batch( 1 ).run( name, [&] {
+		auto rd = optics::compute_reachability_dists( points, min_pts, -1.0, mode, threads );
+		ankerl::nanobench::doNotOptimizeAway( rd.size() );
+	} );
+}
+
+}  // namespace
+
+
+int main() {
+	const unsigned hw = std::max( 1u, std::thread::hardware_concurrency() );
+	ankerl::nanobench::Bench bench;
+	bench.title( "OPTICS perf (hw=" + std::to_string( hw ) + ")" ).warmup( 1 ).relative( false );
+
+	// Hot path that #12 targets. Each lambda call sweeps all points (~ms), so
+	// force several iterations per epoch for a stable median.
+	bench.minEpochIterations( 10 );
+	bench_core_dist<double, 3>( bench, "core_dist 3D double (30k)", 30000, 16 );
+	bench_core_dist<float, 3>( bench, "core_dist 3D float  (30k)", 30000, 16 );
+	bench_core_dist<double, 16>( bench, "core_dist 16D double (8k)", 8000, 16 );
+
+	// End-to-end ordering across modes / threads / precision. A few iterations
+	// per epoch to tame run-to-run variance (each call is ~100 ms).
+	bench.minEpochIterations( 3 );
+	bench_ordering<double, 3>( bench, "ordering 3D double 30k precompute x1", 30000, 16, optics::NeighborMode::Precompute, 1 );
+	bench_ordering<double, 3>( bench, "ordering 3D double 30k precompute xHW", 30000, 16, optics::NeighborMode::Precompute, hw );
+	bench_ordering<double, 3>( bench, "ordering 3D double 30k ondemand x1", 30000, 16, optics::NeighborMode::OnDemand, 1 );
+	bench_ordering<float, 3>( bench, "ordering 3D float 30k precompute xHW", 30000, 16, optics::NeighborMode::Precompute, hw );
+	bench_ordering<double, 16>( bench, "ordering 16D double 8k precompute xHW", 8000, 16, optics::NeighborMode::Precompute, hw );
+
+	std::ofstream csv( "optics_perf.csv" );
+	bench.render( ankerl::nanobench::templates::csv(), csv );
+	std::cout << "\nWrote optics_perf.csv" << std::endl;
+	return 0;
+}

--- a/test/Benchmark/perf.cpp
+++ b/test/Benchmark/perf.cpp
@@ -44,7 +44,7 @@ void bench_core_dist( ankerl::nanobench::Bench& bench, const std::string& name, 
 	bench.batch( points.size() ).run( name, [&] {
 		double acc = 0.0;
 		for ( std::size_t i = 0; i < points.size(); ++i ) {
-			acc += optics::compute_core_dist( points[i], points, nbrs[i], min_pts ).value_or( 0.0 );
+			acc += optics::detail::compute_core_dist( points[i], points, nbrs[i], min_pts ).value_or( 0.0 );
 		}
 		ankerl::nanobench::doNotOptimizeAway( acc );
 	} );

--- a/test/Benchmark/scale.cpp
+++ b/test/Benchmark/scale.cpp
@@ -1,0 +1,49 @@
+// Copyright Ingo Proff 2016.
+// https://github.com/J-D-3/OPTICS-Clustering
+// Distributed under the MIT Software License (X11 license).
+// (See accompanying file LICENSE)
+
+// Large-scale (1e6-1e7) 3D timing harness for the color-space-style workload.
+// Build in a Release config. Usage: optics_scale [n_points]   (default 1000000)
+
+#include <optics/optics.hpp>
+#include <optics/testdata.hpp>
+#include <optics/Stopwatch.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace sw = stopwatch;
+
+template <class T>
+void run( std::size_t n_points ) {
+	const std::size_t min_pts = 16;
+	const auto points = optics::testdata::uniform_noise<T, 3>( n_points, 0.0, 1000.0 );
+	const char* tname = ( sizeof( T ) == 4 ? "float " : "double" );
+
+	sw::Stopwatch w;
+	auto rd1 = optics::compute_reachability_dists( points, min_pts, -1.0, optics::NeighborMode::Precompute, 0 );
+	const auto precompute_ms = w.elapsed<sw::ms>();
+
+	w.restart();
+	auto rd2 = optics::compute_reachability_dists( points, min_pts, -1.0, optics::NeighborMode::OnDemand, 1 );
+	const auto ondemand_ms = w.elapsed<sw::ms>();
+
+	std::cout << "  3D " << tname << " n=" << points.size()
+			  << "  precompute(xHW)=" << precompute_ms << " ms"
+			  << "  ondemand(x1)=" << ondemand_ms << " ms"
+			  << "  (ordered " << rd1.size() << ", " << rd2.size() << ")" << std::endl;
+}
+
+int main( int argc, char** argv ) {
+	std::size_t n = 1000000;
+	if ( argc > 1 ) { n = static_cast<std::size_t>( std::strtoull( argv[1], nullptr, 10 ) ); }
+	std::cout << "OPTICS scale (hw=" << std::max( 1u, std::thread::hardware_concurrency() ) << ")" << std::endl;
+	run<float>( n );
+	run<double>( n );
+	return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,3 +32,7 @@ target_compile_options(optics_benchmark PRIVATE
 add_executable(optics_perf Benchmark/perf.cpp)
 target_link_libraries(optics_perf PRIVATE optics::optics)
 target_include_directories(optics_perf SYSTEM PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/third_party")
+
+# Large-scale (1e6-1e7) 3D timing harness. Release config; not a ctest.
+add_executable(optics_scale Benchmark/scale.cpp)
+target_link_libraries(optics_scale PRIVATE optics::optics)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,22 +1,26 @@
-# Compile flags shared by the test targets: warnings on, and assertions kept
-# live (undefine the NDEBUG that optimized configs inject) since the suites
-# verify behavior via assert().
-set(OPTICS_TEST_OPTIONS
+# Warnings on for all test targets. The visual test still verifies via assert(),
+# so it also needs NDEBUG undefined in optimized configs.
+set(OPTICS_WARN_OPTIONS
     $<$<CXX_COMPILER_ID:MSVC>:/W4>
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>)
+set(OPTICS_ASSERT_OPTIONS
     $<$<CXX_COMPILER_ID:MSVC>:/UNDEBUG>
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-UNDEBUG>)
 
+# Unit suite: doctest (TEST_CASE/CHECK; assertions independent of NDEBUG). The
+# binary runs all cases and reports per-case (use ctest --output-on-failure to
+# see doctest's report); registered once with CTest for cross-platform robustness.
 add_executable(optics_tests test_main.cpp)
 target_link_libraries(optics_tests PRIVATE optics::optics)
-target_compile_options(optics_tests PRIVATE ${OPTICS_TEST_OPTIONS})
+target_include_directories(optics_tests SYSTEM PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/third_party")
+target_compile_options(optics_tests PRIVATE ${OPTICS_WARN_OPTIONS})
 add_test(NAME optics_tests COMMAND optics_tests)
 
 # Visual / export test: clusters synthetic clouds, asserts structure, and emits
 # CSVs for tools/visualize.py.
 add_executable(optics_visual_test ClusterImage_Test/test_ClusterImages.cpp)
 target_link_libraries(optics_visual_test PRIVATE optics::optics)
-target_compile_options(optics_visual_test PRIVATE ${OPTICS_TEST_OPTIONS})
+target_compile_options(optics_visual_test PRIVATE ${OPTICS_WARN_OPTIONS} ${OPTICS_ASSERT_OPTIONS})
 add_test(NAME optics_visual_test COMMAND optics_visual_test)
 
 # Performance benchmark (build in a Release config for meaningful numbers).

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,3 +26,9 @@ target_link_libraries(optics_benchmark PRIVATE optics::optics)
 target_compile_options(optics_benchmark PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/W4>
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>)
+
+# Performance-regression harness (nanobench). Release config; emits optics_perf.csv.
+# Not a ctest (timings vary by machine).
+add_executable(optics_perf Benchmark/perf.cpp)
+target_link_libraries(optics_perf PRIVATE optics::optics)
+target_include_directories(optics_perf SYSTEM PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/third_party")

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -4,6 +4,9 @@
 // (See accompanying file LICENSE)
 
 
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "third_party/doctest.h"
+
 #include "../include/optics/optics.hpp"
 #include "../include/optics/testdata.hpp"
 
@@ -22,7 +25,7 @@ C sorted( C c ) {
 }
 
 
-void clustering_test_1(){
+TEST_CASE("clustering_test_1") {
 	static const int N = 2;
 	typedef std::array<double, N> point; //A list of N cartesian coordinates makes a point
 
@@ -37,14 +40,14 @@ void clustering_test_1(){
 	}*/
 
 	auto clusters = optics::get_cluster_indices(reach_dists, 10);
-	assert(clusters.size() == 3);
-	assert( ( sorted( clusters[0] ) == std::vector <std::size_t>({ 0,1,2 }) ) );
-	assert( ( sorted( clusters[1] ) == std::vector <std::size_t>({ 3,4,5 }) ) );
-	assert( ( sorted( clusters[2] ) == std::vector <std::size_t>({ 6,7,8 }) ) );
+	CHECK(clusters.size() == 3);
+	CHECK( ( sorted( clusters[0] ) == std::vector <std::size_t>({ 0,1,2 }) ) );
+	CHECK( ( sorted( clusters[1] ) == std::vector <std::size_t>({ 3,4,5 }) ) );
+	CHECK( ( sorted( clusters[2] ) == std::vector <std::size_t>({ 6,7,8 }) ) );
 }
 
 
-void clustering_test_2() {
+TEST_CASE("clustering_test_2") {
 	static const int N = 2;
 	typedef std::array<double, N> point; //A list of N cartesian coordinates makes a point
 
@@ -59,14 +62,14 @@ void clustering_test_2() {
 	}*/
 
 	auto clusters = optics::get_cluster_indices( reach_dists, 2 );
-	assert( clusters.size() == 3 );
-	assert( (sorted( clusters[0] ) == std::vector <std::size_t>( { 0,1,2 } )) );
-	assert( (sorted( clusters[1] ) == std::vector <std::size_t>( { 3,4,5 } )) );
-	assert( (sorted( clusters[2] ) == std::vector <std::size_t>( { 6,7,8 } )) );
+	CHECK( clusters.size() == 3 );
+	CHECK( (sorted( clusters[0] ) == std::vector <std::size_t>( { 0,1,2 } )) );
+	CHECK( (sorted( clusters[1] ) == std::vector <std::size_t>( { 3,4,5 } )) );
+	CHECK( (sorted( clusters[2] ) == std::vector <std::size_t>( { 6,7,8 } )) );
 }
 
 
-void clustering_test_3(){
+TEST_CASE("clustering_test_3") {
 	static const int N = 2;
 	typedef std::array<double, N> point; //A list of N cartesian coordinates makes a point
 
@@ -79,17 +82,17 @@ void clustering_test_3(){
 	auto reach_dists = optics::compute_reachability_dists( points, 2, 10 );
 
 	auto clusters = optics::get_cluster_indices( reach_dists, 10 );
-	assert( clusters.size() == 3 );
-	assert( (sorted( clusters[0] ) == std::vector <std::size_t>( { 0,1,2 } )) );
-	assert( (sorted( clusters[1] ) == std::vector <std::size_t>( { 3,4,5 } )) );
-	assert( (sorted( clusters[2] ) == std::vector <std::size_t>( { 6,7,8 } )) );
+	CHECK( clusters.size() == 3 );
+	CHECK( (sorted( clusters[0] ) == std::vector <std::size_t>( { 0,1,2 } )) );
+	CHECK( (sorted( clusters[1] ) == std::vector <std::size_t>( { 3,4,5 } )) );
+	CHECK( (sorted( clusters[2] ) == std::vector <std::size_t>( { 6,7,8 } )) );
 
 	auto cluster_points = optics::get_cluster_points(reach_dists, 10, points);
-	assert( cluster_points.size() == 3 );
+	CHECK( cluster_points.size() == 3 );
 }
 
 
-void epsilon_estimation_test_1() {
+TEST_CASE("epsilon_estimation_test_1") {
 	static const int N = 2;
 	typedef std::array<double, N> point; //A list of N cartesian coordinates makes a point
 
@@ -100,9 +103,9 @@ void epsilon_estimation_test_1() {
 	};
 
 	double epsilon_est = optics::epsilon_estimation( points, 3 );
-	assert( epsilon_est <3.090196 && epsilon_est >3.09019 );
+	CHECK( (epsilon_est < 3.090196 && epsilon_est > 3.09019) );
 }
-void epsilon_estimation_test_2() {
+TEST_CASE("epsilon_estimation_test_2") {
 	static const int N = 3;
 	typedef std::array<double, N> point; //A list of N cartesian coordinates makes a point
 
@@ -112,11 +115,11 @@ void epsilon_estimation_test_2() {
 	};
 
 	double epsilon_est = optics::epsilon_estimation( points, 3 );
-	assert( epsilon_est >2.236750 && epsilon_est <2.236751 );
+	CHECK( (epsilon_est > 2.236750 && epsilon_est < 2.236751) );
 }
 
 
-void chi_test_1(){
+TEST_CASE("chi_test_1") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{1,10.0}, {2,9.0}, {3,9.0}, {4, 5.0},//SDA
 		{5,5.49}, {6,5.0},//Cluster1
@@ -129,9 +132,9 @@ void chi_test_1(){
 	std::size_t min_pts = 4;
    auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
    std::vector<std::pair<std::size_t, std::size_t>> exp ({ {2, 5}, {0, 11}, { 6,10 } });
-   assert( clusters == exp );
+   CHECK( clusters == exp );
 }
-void chi_test_2() {
+TEST_CASE("chi_test_2") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,10.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -146,9 +149,9 @@ void chi_test_2() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 10 },{ 6,10 }, {11,16} } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 10 },{ 6,10 }, {11,16} } )) );
 }
-void chi_test_3() {
+TEST_CASE("chi_test_3") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,11.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -163,9 +166,9 @@ void chi_test_3() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{0,16},{ 11,16 } } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{0,16},{ 11,16 } } )) );
 }
-void chi_test_4() {
+TEST_CASE("chi_test_4") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,12.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -180,9 +183,9 @@ void chi_test_4() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{0,16},{ 11,16 } } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{0,16},{ 11,16 } } )) );
 }
-void chi_test_5() {
+TEST_CASE("chi_test_5") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,12.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -197,9 +200,9 @@ void chi_test_5() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{0,16},{ 11,16 } } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{0,16},{ 11,16 } } )) );
 }
-void chi_test_6() {
+TEST_CASE("chi_test_6") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,12.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -213,9 +216,9 @@ void chi_test_6() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{2,15},{ 11,15 } } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 2, 5 },{ 0, 9 },{ 6,10 },{2,15},{ 11,15 } } )) );
 }
-void chi_test_7() {
+TEST_CASE("chi_test_7") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,12.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -229,9 +232,9 @@ void chi_test_7() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 5 },{ 6, 9 },{6,15},{ 11,15 } } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 5 },{ 6, 9 },{6,15},{ 11,15 } } )) );
 }
-void chi_test_8() {
+TEST_CASE("chi_test_8") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,12.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -245,9 +248,9 @@ void chi_test_8() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 5 },{ 6, 9 },{ 11,15 } } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 5 },{ 6, 9 },{ 11,15 } } )) );
 }
-void chi_test_9() {
+TEST_CASE("chi_test_9") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 0, 5.0 }, { 1,5.49 },{ 2,5.0 },//Cluster1
 		{ 3, 11.0 },//SUA
@@ -260,9 +263,9 @@ void chi_test_9() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 2 },{ 3, 6 },{ 3,12 }, {8,12} } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 2 },{ 3, 6 },{ 3,12 }, {8,12} } )) );
 }
-void chi_test_10() {
+TEST_CASE("chi_test_10") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 0, 5.0 }, { 1,5.49 },{ 2,5.0 },//Cluster1
 		{ 3, 11.0 },//SUA
@@ -275,14 +278,14 @@ void chi_test_10() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts );
-	assert( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 2 },{ 3, 6 }, {8,12} } )) );
+	CHECK( (clusters == std::vector<std::pair<std::size_t, std::size_t>>( { { 0, 2 },{ 3, 6 }, {8,12} } )) );
 }
 
 
 // The neighbor sets are identical regardless of how they are acquired, so the
 // reachability ordering must be byte-for-byte identical across Precompute (any
 // thread count) and OnDemand. This pins the P4 parallelism/mode machinery.
-void neighbor_mode_tests() {
+TEST_CASE("neighbor_mode_tests") {
 	static const int N = 2;
 	typedef std::array<double, N> point;
 
@@ -304,24 +307,15 @@ void neighbor_mode_tests() {
 	const auto precompute_4t = optics::compute_reachability_dists( points, min_pts, -1.0, optics::NeighborMode::Precompute, 4 );
 	const auto on_demand = optics::compute_reachability_dists( points, min_pts, -1.0, optics::NeighborMode::OnDemand, 1 );
 
-	assert( baseline.size() == points.size() );
-	assert( precompute_4t == baseline );
-	assert( on_demand == baseline );
+	CHECK( baseline.size() == points.size() );
+	CHECK( precompute_4t == baseline );
+	CHECK( on_demand == baseline );
 
 	std::cout << "Neighbor-mode parity tests successful!" << std::endl;
 }
 
 
-void clustering_tests() {
-	clustering_test_1();
-	clustering_test_2();
-	clustering_test_3();
-
-	std::cout << "Clustering tests successful!" << std::endl;
-}
-
-
-void chi_test_11(){
+TEST_CASE("chi_test_11") {
    std::vector<optics::reachability_dist> reach_dists = {
 	   {0,-1.000000}, {1,-1.000000}, {2,-1.000000}, {3,-1.000000}, {4,-1.000000}, {5,-1.000000}, {6,-1.000000}, {7,-1.000000}, {8,-1.000000},
 	   {9,-1.000000}, {10,-1.000000}, {11,-1.000000}, {12,-1.000000}, {13,-1.000000}, {14,-1.000000}, {15,-1.000000}, {16,-1.000000},
@@ -440,7 +434,7 @@ void chi_test_11(){
 	   auto clusters = optics::get_chi_clusters_flat( reach_dists, chi, min_pts, steep_area_min_diff );
 	   std::vector<std::pair<std::size_t, std::size_t>> expected_result =
 	   { { 155, 162 },{ 203, 225 },{ 295, 299 },{ 300, 304 },{ 271, 358 },{ 270, 372 },{ 150, 407 },{ 422, 493 },{ 590, 607 },{ 626, 642 },{ 412, 684 },{ 700, 711 } };
-	   assert( (clusters == expected_result) );
+	   CHECK( (clusters == expected_result) );
    }
 
    {
@@ -452,37 +446,12 @@ void chi_test_11(){
 	   std::vector<std::pair<std::size_t, std::size_t>> expected_result =
 		{ {155, 160}, {208, 217}, {276, 321}, {271, 355}, {150, 407}, {425, 470},
 		{425, 487}, {598, 606}, {626, 642}, {623, 650}, {412, 684}, {700, 711} };
-	   assert( (clusters2 == expected_result) );
+	   CHECK( (clusters2 == expected_result) );
    }
 }
 
 
-void chi_cluster_tests(){
-	chi_test_1();
-	chi_test_2();
-	chi_test_3();
-	chi_test_4();
-	chi_test_5();
-	chi_test_6();
-	chi_test_7();
-	chi_test_8();
-	chi_test_9();
-	chi_test_10();
-	chi_test_11();
-
-	std::cout << "Chi cluster extraction tests successful!" << std::endl;
-}
-
-
-void epsilon_estimation_tests(){
-	epsilon_estimation_test_1();
-	epsilon_estimation_test_2();
-
-	std::cout << "Epsilon estimation tests successful!" << std::endl;
-}
-
-
-void tree_tests() {
+TEST_CASE("tree_tests") {
 	typedef std::pair<std::size_t, std::size_t> cluster;
 	typedef optics::Node<cluster> Node;
 
@@ -490,14 +459,14 @@ void tree_tests() {
 		optics::Node<cluster> n( { 0,5 } );
 		optics::Tree<cluster> T( n );
 		auto c = T.flatten();
-		assert( c == std::vector<cluster>( { cluster( 0, 5 ) } ) );
+		CHECK( c == std::vector<cluster>( { cluster( 0, 5 ) } ) );
 	}
 
 	{
 		optics::Node<cluster> n( { 0,5 } );
 		optics::Tree<cluster> T( n );
 		auto c = T.flatten();
-		assert( c == std::vector<cluster>( { cluster( 0, 5 ) } ) );
+		CHECK( c == std::vector<cluster>( { cluster( 0, 5 ) } ) );
 	}
 
 	{
@@ -531,7 +500,7 @@ bool trees_are_equal( const optics::Node<optics::chi_cluster_indices>& t1, const
 	return true;
 }
 
-void chi_cluster_tree_tests_1() {
+TEST_CASE("chi_cluster_tree_tests_1") {
 	std::vector<optics::reachability_dist> reach_dists = {
 		{ 1,10.0 },{ 2,9.0 },{ 3,9.0 },{ 4, 5.0 },//SDA
 		{ 5,5.49 },{ 6,5.0 },//Cluster1
@@ -543,7 +512,7 @@ void chi_cluster_tree_tests_1() {
 	double chi = 0.1;
 	std::size_t min_pts = 4;
 	auto clusters = optics::get_chi_clusters( reach_dists, chi, min_pts );
-	assert( clusters.size() == 1 );
+	CHECK( clusters.size() == 1 );
 
 	optics::cluster_tree expected_result =
 	{
@@ -555,11 +524,11 @@ void chi_cluster_tree_tests_1() {
 			}
 		}
 	};
-	assert( trees_are_equal(clusters.front().get_root(), expected_result.get_root() ) );
+	CHECK( trees_are_equal(clusters.front().get_root(), expected_result.get_root() ) );
 }
 
 
-void chi_cluster_tree_tests_2() {
+TEST_CASE("chi_cluster_tree_tests_2") {
 	std::vector<optics::chi_cluster_indices> flat_clusters = {
 		{0,4}, {0,8}, {5,7},
 		{9,10}, {12,13}, {9,17}, {11,17}, {13,14}, {8,20}
@@ -590,27 +559,17 @@ void chi_cluster_tree_tests_2() {
 	});
 
 	auto clusters = optics::flat_clusters_to_tree( flat_clusters );
-	assert( clusters.size() == 2 );
-	assert( trees_are_equal( clusters[0].get_root(), expected_result[0].get_root() ) );
-	assert( trees_are_equal( clusters[1].get_root(), expected_result[1].get_root() ) );
+	CHECK( clusters.size() == 2 );
+	CHECK( trees_are_equal( clusters[0].get_root(), expected_result[0].get_root() ) );
+	CHECK( trees_are_equal( clusters[1].get_root(), expected_result[1].get_root() ) );
 }
-
-
-void chi_cluster_tree_tests() {
-	chi_cluster_tree_tests_1();
-	chi_cluster_tree_tests_2();
-
-	std::cout << "Chi-Cluster-Tree tests successful!" << std::endl;
-}
-
-
 
 
 #ifdef OPTICS_ENABLE_BOOST_RTREE
 // Only built when the optional Boost backend is enabled. Verifies that the
 // Boost R*-tree backend returns the same neighbor sets as nanoflann, and that
 // it produces the same number of clusters end-to-end.
-void boost_backend_tests() {
+TEST_CASE("boost_backend_tests") {
 	static const int N = 2;
 	typedef std::array<double, N> point;
 	const std::vector<point> centers = { { 0, 0 }, { 60, 0 }, { 30, 50 } };
@@ -623,31 +582,15 @@ void boost_backend_tests() {
 		std::vector<std::size_t> a, b;
 		nano.radius_search( points[i], eps, a );
 		boost_be.radius_search( points[i], eps, b );
-		assert( sorted( a ) == sorted( b ) );
+		CHECK( sorted( a ) == sorted( b ) );
 	}
 
 	const auto reach_boost = optics::compute_reachability_dists<double, N, optics::BoostRTreeBackend<double, N>>( points, 10, 10.0 );
 	const auto clusters = optics::get_cluster_indices( reach_boost, 10.0 );
 	std::size_t large = 0;
 	for ( const auto& c : clusters ) { if ( c.size() >= 50 ) ++large; }
-	assert( large == 3 );
+	CHECK( large == 3 );
 
 	std::cout << "Boost backend equivalence tests successful!" << std::endl;
 }
 #endif
-
-
-int main()
-{
-	tree_tests();
-	epsilon_estimation_tests();
-	chi_cluster_tests();
-	chi_cluster_tree_tests();
-	clustering_tests();
-	neighbor_mode_tests();
-#ifdef OPTICS_ENABLE_BOOST_RTREE
-	boost_backend_tests();
-#endif
-
-	return 0;
-}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -649,6 +649,64 @@ TEST_CASE("reference: library matches brute-force O(n^2) OPTICS") {
 	}
 }
 
+TEST_CASE("edge cases and degenerate inputs") {
+	using P2 = std::array<double, 2>;
+
+	// Empty input -> empty result.
+	CHECK( optics::compute_reachability_dists( std::vector<P2>{}, 5 ).empty() );
+
+	// min_pts must be >= 1.
+	std::vector<P2> two = { { 0, 0 }, { 1, 1 } };
+	CHECK_THROWS_AS( optics::compute_reachability_dists( two, 0 ), std::invalid_argument );
+
+	// Fewer points than min_pts: everything is unreached (core-distance UNDEFINED).
+	std::vector<P2> few = { { 0, 0 }, { 1, 0 }, { 0, 1 } };
+	const auto rd_few = optics::compute_reachability_dists( few, 10, 5.0 );
+	CHECK( rd_few.size() == 3 );
+	bool all_undefined = true;
+	for ( const auto& r : rd_few ) { if ( r.reach_dist >= 0.0 ) all_undefined = false; }
+	CHECK( all_undefined );
+
+	// All-identical points: auto-epsilon is 0, which still groups them into one cluster.
+	std::vector<P2> identical( 20, P2{ 3.0, 3.0 } );
+	const auto rd_id = optics::compute_reachability_dists( identical, 5 );
+	CHECK( rd_id.size() == 20 );
+	const auto cl_id = optics::get_cluster_indices( rd_id, 1.0 );
+	CHECK( cl_id.size() == 1 );
+	CHECK( cl_id[0].size() == 20 );
+
+	// Collinear (y constant): the effective-dimension epsilon estimate must still
+	// separate three groups along the x-axis (would fail with a 0/degenerate volume).
+	std::vector<P2> line;
+	for ( int g = 0; g < 3; ++g ) {
+		for ( int i = 0; i < 10; ++i ) { line.push_back( { g * 30.0 + i * 0.5, 0.0 } ); }
+	}
+	const auto rd_line = optics::compute_reachability_dists( line, 4 );  // auto epsilon, d_eff == 1
+	const auto cl_line = optics::get_cluster_indices( rd_line, 5.0 );
+	std::size_t big_line = 0;
+	for ( const auto& c : cl_line ) { if ( c.size() >= 5 ) ++big_line; }
+	CHECK( big_line == 3 );
+
+	// float vs double produce the same cluster structure.
+	const std::vector<P2> centers = { { 0, 0 }, { 40, 0 }, { 20, 35 } };
+	const auto pd = optics::testdata::gaussian_blobs<double, 2>( centers, 40, 1.5 );
+	const auto pf = optics::convert_cloud<float>( pd );
+	const auto large = []( const std::vector<std::vector<std::size_t>>& cs ) {
+		std::size_t k = 0;
+		for ( const auto& c : cs ) { if ( c.size() >= 20 ) ++k; }
+		return k;
+	};
+	const auto big_d = large( optics::cluster_dbscan( pd, 5, 12.0 ) );
+	const auto big_f = large( optics::cluster_dbscan( pf, 5, 12.0 ) );
+	CHECK( big_d == 3 );
+	CHECK( big_d == big_f );
+
+	// Determinism: identical results across repeated multi-threaded runs.
+	const auto r1 = optics::compute_reachability_dists( pd, 5, 12.0, optics::NeighborMode::Precompute, 8 );
+	const auto r2 = optics::compute_reachability_dists( pd, 5, 12.0, optics::NeighborMode::Precompute, 8 );
+	CHECK( r1 == r2 );
+}
+
 TEST_CASE("convenience: convert_cloud + cluster_dbscan + extract_xi") {
 	// Integer cloud (e.g. color-ish data) -> float, then a one-call DBSCAN cut.
 	std::vector<std::array<int, 2>> int_pts = {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -13,7 +13,9 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <optional>
 #include <random>
+#include <set>
 #include <vector>
 
 
@@ -564,6 +566,88 @@ TEST_CASE("chi_cluster_tree_tests_2") {
 	CHECK( trees_are_equal( clusters[1].get_root(), expected_result[1].get_root() ) );
 }
 
+
+// Naive O(n^2) OPTICS reference: brute-force neighbor scan + linear-scan seed
+// selection. Uses the same distance primitives so the ordering must match the
+// optimized library bit-for-bit; the independence is in the control flow
+// (no kd-tree, no heap), which is exactly what we want to validate.
+template <class T, std::size_t Dim>
+std::vector<optics::reachability_dist> brute_force_optics(
+	const std::vector<std::array<T, Dim>>& points, std::size_t min_pts, double eps ) {
+	const std::size_t n = points.size();
+	const double eps2 = eps * eps;
+	std::vector<char> processed( n, 0 );
+	std::vector<double> reach( n, -1.0 );
+	std::vector<std::size_t> order;
+	std::set<std::size_t> seeds;
+
+	const auto neighbors = [&]( std::size_t i ) {
+		std::vector<std::size_t> r;
+		for ( std::size_t j = 0; j < n; ++j ) {
+			if ( optics::detail::square_dist( points[i], points[j] ) <= eps2 ) { r.push_back( j ); }
+		}
+		return r;
+	};
+	const auto core_dist = [&]( std::size_t i, const std::vector<std::size_t>& nb ) -> std::optional<double> {
+		if ( nb.size() < min_pts ) { return std::nullopt; }
+		std::vector<double> sq;
+		for ( std::size_t j : nb ) { sq.push_back( optics::detail::square_dist( points[i], points[j] ) ); }
+		std::sort( sq.begin(), sq.end() );
+		return std::sqrt( sq[min_pts - 1] );
+	};
+	const auto relax = [&]( std::size_t i, const std::vector<std::size_t>& nb, double cd ) {
+		for ( std::size_t o : nb ) {
+			if ( processed[o] ) { continue; }
+			const double nrd = std::max( cd, optics::detail::dist( points[i], points[o] ) );
+			if ( reach[o] < 0.0 || nrd < reach[o] ) { reach[o] = nrd; seeds.insert( o ); }
+		}
+	};
+
+	for ( std::size_t i = 0; i < n; ++i ) {
+		if ( processed[i] ) { continue; }
+		processed[i] = 1;
+		order.push_back( i );
+		auto nb = neighbors( i );
+		if ( auto cd = core_dist( i, nb ) ) { relax( i, nb, *cd ); }
+		while ( !seeds.empty() ) {
+			const std::size_t best = *std::min_element( seeds.begin(), seeds.end(),
+				[&]( std::size_t a, std::size_t b ) { return reach[a] != reach[b] ? reach[a] < reach[b] : a < b; } );
+			seeds.erase( best );
+			if ( processed[best] ) { continue; }
+			processed[best] = 1;
+			order.push_back( best );
+			auto nb2 = neighbors( best );
+			if ( auto cd = core_dist( best, nb2 ) ) { relax( best, nb2, *cd ); }
+		}
+	}
+	std::vector<optics::reachability_dist> result;
+	for ( std::size_t idx : order ) { result.emplace_back( idx, reach[idx] ); }
+	return result;
+}
+
+TEST_CASE("reference: library matches brute-force O(n^2) OPTICS") {
+	// 2D: three well-separated blobs (no pairwise distance near eps).
+	{
+		const std::vector<std::array<double, 2>> centers = { { 0, 0 }, { 40, 0 }, { 20, 35 } };
+		const auto points = optics::testdata::gaussian_blobs<double, 2>( centers, 40, 1.5 );
+		const std::size_t min_pts = 5;
+		const double eps = 15.0;
+		const auto ref = brute_force_optics( points, min_pts, eps );
+		CHECK( optics::compute_reachability_dists( points, min_pts, eps, optics::NeighborMode::Precompute, 4 ) == ref );
+		CHECK( optics::compute_reachability_dists( points, min_pts, eps, optics::NeighborMode::OnDemand, 1 ) == ref );
+	}
+	// 3D, with some noise points (undefined core-distance paths).
+	{
+		const std::vector<std::array<double, 3>> centers = { { 0, 0, 0 }, { 50, 0, 0 }, { 0, 50, 0 } };
+		auto points = optics::testdata::gaussian_blobs<double, 3>( centers, 50, 2.0 );
+		const auto noise = optics::testdata::uniform_noise<double, 3>( 15, -30.0, 80.0, 99 );
+		points.insert( points.end(), noise.begin(), noise.end() );
+		const std::size_t min_pts = 6;
+		const double eps = 10.0;
+		const auto ref = brute_force_optics( points, min_pts, eps );
+		CHECK( optics::compute_reachability_dists( points, min_pts, eps ) == ref );
+	}
+}
 
 TEST_CASE("convenience: convert_cloud + cluster_dbscan + extract_xi") {
 	// Integer cloud (e.g. color-ish data) -> float, then a one-call DBSCAN cut.

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -565,6 +565,23 @@ TEST_CASE("chi_cluster_tree_tests_2") {
 }
 
 
+TEST_CASE("convenience: convert_cloud + cluster_dbscan + extract_xi") {
+	// Integer cloud (e.g. color-ish data) -> float, then a one-call DBSCAN cut.
+	std::vector<std::array<int, 2>> int_pts = {
+		{ 100,100 },{ 102,100 },{ 101,101 }, { 0,0 },{ 1,0 },{ 0,1 }, { -100,-100 },{ -102,-100 },{ -101,-101 } };
+	auto cloud = optics::convert_cloud<float>( int_pts );
+	auto clusters = optics::cluster_dbscan( cloud, 2, 10.0 );
+	CHECK( clusters.size() == 3 );
+
+	// Xi clusters as point-index lists from a cluster-ordering.
+	std::vector<optics::reachability_dist> reach_dists = {
+		{ 1,10.0 },{ 2,9.0 },{ 3,9.0 },{ 4,5.0 },{ 5,5.49 },{ 6,5.0 },
+		{ 7,6.5 },{ 8,3.0 },{ 9,2.9 },{ 10,2.8 },{ 11,10.0 },{ 12,12.0 } };
+	auto xi = optics::extract_xi( reach_dists, 0.1, 4 );
+	CHECK( xi.size() == 3 );
+}
+
+
 #ifdef OPTICS_ENABLE_BOOST_RTREE
 // Only built when the optional Boost backend is enabled. Verifies that the
 // Boost R*-tree backend returns the same neighbor sets as nanoflann, and that

--- a/test/third_party/doctest.h
+++ b/test/third_party/doctest.h
@@ -1,0 +1,9119 @@
+// =============================================================
+// == DO NOT MODIFY THIS FILE BY HAND - IT IS AUTO GENERATED! ==
+// =============================================================
+//
+// doctest.h - the lightest feature-rich C++ single-header testing framework for unit tests and TDD
+//
+// Copyright (c) 2016-2023 Viktor Kirilov
+//
+// Distributed under the MIT Software License
+// See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/MIT
+//
+// The documentation can be found at the library's page:
+// https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
+//
+// =================================================================================================
+// =================================================================================================
+// =================================================================================================
+//
+// The library is heavily influenced by Catch - https://github.com/catchorg/Catch2
+// which uses the Boost Software License - Version 1.0
+// see here - https://github.com/catchorg/Catch2/blob/master/LICENSE.txt
+//
+// The concept of subcases (sections in Catch) and expression decomposition are from there.
+// Some parts of the code are taken directly:
+// - stringification - the detection of "ostream& operator<<(ostream&, const T&)" and StringMaker<>
+// - the Approx() helper class for floating point comparison
+// - colors in the console
+// - breaking into a debugger
+// - signal / SEH handling
+// - timer
+// - XmlWriter class - thanks to Phil Nash for allowing the direct reuse (AKA copy/paste)
+//
+// The expression decomposing templates are taken from lest - https://github.com/martinmoene/lest
+// which uses the Boost Software License - Version 1.0
+// see here - https://github.com/martinmoene/lest/blob/master/LICENSE.txt
+//
+// =================================================================================================
+// =================================================================================================
+// =================================================================================================
+
+#ifndef DOCTEST_LIBRARY_INCLUDED
+#define DOCTEST_LIBRARY_INCLUDED
+
+// =================================================================================================
+// == VERSION ======================================================================================
+// =================================================================================================
+
+#ifndef DOCTEST_PARTS_PUBLIC_VERSION
+#define DOCTEST_PARTS_PUBLIC_VERSION
+
+// NOLINTBEGIN(cppcoreguidelines-macro-to-enum, modernize-macro-to-enum)
+#define DOCTEST_VERSION_MAJOR 2
+#define DOCTEST_VERSION_MINOR 5
+#define DOCTEST_VERSION_PATCH 0
+// NOLINTEND(cppcoreguidelines-macro-to-enum, modernize-macro-to-enum)
+
+// util we need here
+#define DOCTEST_TOSTR_IMPL(x) #x
+#define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
+
+// clang-format off
+#define DOCTEST_VERSION_STR                                                                                            \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                                           \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                                           \
+    DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
+// clang-format on
+
+#define DOCTEST_VERSION (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
+
+#endif // DOCTEST_PARTS_PUBLIC_VERSION
+// =================================================================================================
+// == COMPILER VERSION =============================================================================
+// =================================================================================================
+
+#ifndef DOCTEST_PARTS_PUBLIC_COMPILER
+#define DOCTEST_PARTS_PUBLIC_COMPILER
+
+// ideas for the version stuff are taken from here: https://github.com/cxxstuff/cxx_detect
+
+#ifdef _MSC_VER
+#define DOCTEST_CPLUSPLUS _MSVC_LANG
+#else
+#define DOCTEST_CPLUSPLUS __cplusplus
+#endif
+
+#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR) * 10000000 + (MINOR) * 100000 + (PATCH))
+
+// GCC/Clang and GCC/MSVC are mutually exclusive, but Clang/MSVC are not because of clang-cl...
+#if defined(_MSC_VER) && defined(_MSC_FULL_VER)
+#if _MSC_VER == _MSC_FULL_VER / 10000
+#define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
+#else // MSVC
+#define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
+#endif // MSVC
+#endif // MSVC
+#if defined(__clang__) && defined(__clang_minor__) && defined(__clang_patchlevel__)
+#define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && !defined(__INTEL_COMPILER)
+#define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#endif // GCC
+#if defined(__INTEL_COMPILER)
+#define DOCTEST_ICC DOCTEST_COMPILER(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, 0)
+#endif // ICC
+
+#ifndef DOCTEST_MSVC
+#define DOCTEST_MSVC 0
+#endif // DOCTEST_MSVC
+#ifndef DOCTEST_CLANG
+#define DOCTEST_CLANG 0
+#endif // DOCTEST_CLANG
+#ifndef DOCTEST_GCC
+#define DOCTEST_GCC 0
+#endif // DOCTEST_GCC
+#ifndef DOCTEST_ICC
+#define DOCTEST_ICC 0
+#endif // DOCTEST_ICC
+
+#endif // DOCTEST_PARTS_PUBLIC_COMPILER
+// =================================================================================================
+// == COMPILER WARNINGS HELPERS ====================================================================
+// =================================================================================================
+
+#ifndef DOCTEST_PARTS_PUBLIC_WARNINGS
+#define DOCTEST_PARTS_PUBLIC_WARNINGS
+
+
+#if DOCTEST_CLANG && !DOCTEST_ICC
+#define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
+#define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                                    \
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH DOCTEST_CLANG_SUPPRESS_WARNING(w)
+#else // DOCTEST_CLANG
+#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+#define DOCTEST_CLANG_SUPPRESS_WARNING(w)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
+#endif // DOCTEST_CLANG
+
+#if DOCTEST_GCC
+#define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
+#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
+#define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
+#define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
+#else // DOCTEST_GCC
+#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+#define DOCTEST_GCC_SUPPRESS_WARNING(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING_POP
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
+#endif // DOCTEST_GCC
+
+#if DOCTEST_MSVC
+#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
+#define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
+#define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#else // DOCTEST_MSVC
+#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+#define DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
+#endif // DOCTEST_MSVC
+
+// =================================================================================================
+// == COMPILER WARNINGS ============================================================================
+// =================================================================================================
+
+// both the header and the implementation suppress all of these,
+// so it only makes sense to aggregate them like so
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-warning-option")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                                             \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-macros")                                                                  \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")                                                                          \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")                                                                           \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")                                                                     \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")                                                                         \
+                                                                                                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                                                 \
+    /* these 4 also disabled globally via cmake: */                                                                    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4514) /* unreferenced inline function has been removed */                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                                    \
+    /* common ones */                                                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4706) /* assignment within conditional expression */                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4512) /* 'class' : assignment operator could not be generated */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4127) /* conditional expression is constant */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */                            \
+    /* static analysis */                                                                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */                           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26812) /* Prefer 'enum class' over 'enum' */
+
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                                           \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING_POP                                                                                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+#define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH                                                                          \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                              \
+                                                                                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdeprecated")                                                                     \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wctor-dtor-privacy")                                                                \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-promo")                                                                       \
+                                                                                                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */
+
+#define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
+
+#define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH                                                                         \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                              \
+                                                                                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wglobal-constructors")                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wshorten-64-to-32")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-variable-declarations")                                                  \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch")                                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")                                                                    \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-noreturn")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")                                                                 \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")                                                     \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-function")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")                                                                           \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-braces")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch")                                                                           \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")                                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")                                                        \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")                                                                \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnrvo")                                                                             \
+                                                                                                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4267) /* conversion from 'x' to 'y', possible loss of data */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4530) /* exception handler, but unwind semantics not enabled */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4577) /* 'noexcept' with no exception handling mode specified */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string in argument is not a string literal */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4800) /* forcing value to bool (performance warning) */                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5245) /* unreferenced function with internal linkage removed */
+
+#define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
+
+#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4548) /* before comma no effect; expected side - effect */                           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4265) /* virtual functions, but destructor is not virtual */                         \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4986) /* exception specification does not match previous */                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4350) /* 'member1' called instead of 'member2' */                                    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4668) /* not defined as a preprocessor macro */                                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string not a string literal */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */                         \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5262) /* implicit fall-through */
+
+#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_WARNINGS
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+// =================================================================================================
+// == FEATURE DETECTION ============================================================================
+// =================================================================================================
+
+#ifndef DOCTEST_PARTS_PUBLIC_CONFIG
+#define DOCTEST_PARTS_PUBLIC_CONFIG
+
+#ifndef DOCTEST_PARTS_PUBLIC_PLATFORM
+#define DOCTEST_PARTS_PUBLIC_PLATFORM
+
+#if defined(__APPLE__)
+// Apple detection taken from Catch2 codebase
+// For <TargetConditionals.h> information:
+//   https://github.com/swiftlang/swift-corelibs-foundation/blob/release/5.10/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
+#include <TargetConditionals.h>
+#if (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1) || (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1)
+#define DOCTEST_PLATFORM_MAC
+
+#elif defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1
+#define DOCTEST_PLATFORM_IPHONE
+#endif
+
+#elif defined(WIN32) || defined(_WIN32)
+#define DOCTEST_PLATFORM_WINDOWS
+
+#elif defined(__wasi__)
+#define DOCTEST_PLATFORM_WASI
+
+#else // defined(linux) || defined(__linux) // defined(__linux__)
+#define DOCTEST_PLATFORM_LINUX
+#endif // DOCTEST_PLATFORM
+
+#endif // DOCTEST_PARTS_PUBLIC_PLATFORM
+
+// general compiler feature support table: https://en.cppreference.com/w/cpp/compiler_support
+// MSVC C++11 feature support table: https://msdn.microsoft.com/en-us/library/hh567368.aspx
+// GCC C++11 feature support table: https://gcc.gnu.org/projects/cxx-status.html
+// MSVC version table:
+// https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
+// MSVC++ 14.3 (17) _MSC_VER == 1930 (Visual Studio 2022)
+// MSVC++ 14.2 (16) _MSC_VER == 1920 (Visual Studio 2019)
+// MSVC++ 14.1 (15) _MSC_VER == 1910 (Visual Studio 2017)
+// MSVC++ 14.0      _MSC_VER == 1900 (Visual Studio 2015)
+// MSVC++ 12.0      _MSC_VER == 1800 (Visual Studio 2013)
+// MSVC++ 11.0      _MSC_VER == 1700 (Visual Studio 2012)
+// MSVC++ 10.0      _MSC_VER == 1600 (Visual Studio 2010)
+// MSVC++ 9.0       _MSC_VER == 1500 (Visual Studio 2008)
+// MSVC++ 8.0       _MSC_VER == 1400 (Visual Studio 2005)
+
+// Universal Windows Platform support
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#define DOCTEST_CONFIG_NO_WINDOWS_SEH
+#endif // WINAPI_FAMILY
+#if DOCTEST_MSVC && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
+#define DOCTEST_CONFIG_WINDOWS_SEH
+#endif // MSVC
+#if defined(DOCTEST_CONFIG_NO_WINDOWS_SEH) && defined(DOCTEST_CONFIG_WINDOWS_SEH)
+#undef DOCTEST_CONFIG_WINDOWS_SEH
+#endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
+
+#if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(__EMSCRIPTEN__) &&     \
+    !defined(__wasi__)
+#define DOCTEST_CONFIG_POSIX_SIGNALS
+#endif // _WIN32
+#if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
+#undef DOCTEST_CONFIG_POSIX_SIGNALS
+#endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND) || defined(__wasi__)
+#define DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif // no exceptions
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+#define DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+
+#if defined(DOCTEST_CONFIG_NO_EXCEPTIONS) && !defined(DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
+#define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS && !DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+
+#ifdef __wasi__
+#define DOCTEST_CONFIG_NO_MULTITHREADING
+#endif
+
+#if defined(DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN) && !defined(DOCTEST_CONFIG_IMPLEMENT)
+#define DOCTEST_CONFIG_IMPLEMENT
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#if DOCTEST_MSVC
+#define DOCTEST_SYMBOL_EXPORT __declspec(dllexport)
+#define DOCTEST_SYMBOL_IMPORT __declspec(dllimport)
+#else // MSVC
+#define DOCTEST_SYMBOL_EXPORT __attribute__((dllexport))
+#define DOCTEST_SYMBOL_IMPORT __attribute__((dllimport))
+#endif // MSVC
+#else  // _WIN32
+#define DOCTEST_SYMBOL_EXPORT __attribute__((visibility("default")))
+#define DOCTEST_SYMBOL_IMPORT
+#endif // _WIN32
+
+#ifdef DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#ifdef DOCTEST_CONFIG_IMPLEMENT
+#define DOCTEST_INTERFACE DOCTEST_SYMBOL_EXPORT
+#else // DOCTEST_CONFIG_IMPLEMENT
+#define DOCTEST_INTERFACE DOCTEST_SYMBOL_IMPORT
+#endif // DOCTEST_CONFIG_IMPLEMENT
+#else  // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#define DOCTEST_INTERFACE
+#endif // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+
+// needed for extern template instantiations
+// see https://github.com/fmtlib/fmt/issues/2228
+#if DOCTEST_MSVC
+#define DOCTEST_INTERFACE_DECL
+#define DOCTEST_INTERFACE_DEF DOCTEST_INTERFACE
+#else // DOCTEST_MSVC
+#define DOCTEST_INTERFACE_DECL DOCTEST_INTERFACE
+#define DOCTEST_INTERFACE_DEF
+#endif // DOCTEST_MSVC
+
+#define DOCTEST_EMPTY
+
+#if DOCTEST_MSVC
+#define DOCTEST_NOINLINE __declspec(noinline)
+#define DOCTEST_UNUSED
+#define DOCTEST_ALIGNMENT(x)
+#elif DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 5, 0)
+#define DOCTEST_NOINLINE
+#define DOCTEST_UNUSED
+#define DOCTEST_ALIGNMENT(x)
+#else
+#define DOCTEST_NOINLINE __attribute__((noinline))
+#define DOCTEST_UNUSED __attribute__((unused))
+#define DOCTEST_ALIGNMENT(x) __attribute__((aligned(x)))
+#endif
+
+#ifdef DOCTEST_CONFIG_NO_CONTRADICTING_INLINE
+#define DOCTEST_INLINE_NOINLINE inline
+#else
+#define DOCTEST_INLINE_NOINLINE inline DOCTEST_NOINLINE
+#endif
+
+#ifndef DOCTEST_NORETURN
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_NORETURN
+#else // DOCTEST_MSVC
+#define DOCTEST_NORETURN [[noreturn]]
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_NORETURN
+
+#ifndef DOCTEST_NOEXCEPT
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_NOEXCEPT
+#else // DOCTEST_MSVC
+#define DOCTEST_NOEXCEPT noexcept
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_NOEXCEPT
+
+#ifndef DOCTEST_CONSTEXPR
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_CONSTEXPR const
+#define DOCTEST_CONSTEXPR_FUNC inline
+#else // DOCTEST_MSVC
+#define DOCTEST_CONSTEXPR constexpr
+#define DOCTEST_CONSTEXPR_FUNC constexpr
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_CONSTEXPR
+
+#ifndef DOCTEST_NO_SANITIZE_INTEGER
+#if DOCTEST_CLANG >= DOCTEST_COMPILER(3, 7, 0)
+#define DOCTEST_NO_SANITIZE_INTEGER __attribute__((no_sanitize("integer")))
+#else
+#define DOCTEST_NO_SANITIZE_INTEGER
+#endif
+#endif // DOCTEST_NO_SANITIZE_INTEGER
+
+// this is kept here for backwards compatibility since the config option was changed
+#ifdef DOCTEST_CONFIG_USE_IOSFWD
+#ifndef DOCTEST_CONFIG_USE_STD_HEADERS
+#define DOCTEST_CONFIG_USE_STD_HEADERS
+#endif
+#endif // DOCTEST_CONFIG_USE_IOSFWD
+
+// for clang - always include <version> or <ciso646> (which drags some std stuff)
+// because we want to check if we are using libc++ with the _LIBCPP_VERSION macro in
+// which case we don't want to forward declare stuff from std - for reference:
+// https://github.com/doctest/doctest/issues/126
+// https://github.com/doctest/doctest/issues/356
+#if DOCTEST_CLANG
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#if DOCTEST_CPLUSPLUS >= 201703L && __has_include(<version>)
+#include <version>
+#else
+#include <ciso646>
+#endif
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+#endif // clang
+
+#ifdef _LIBCPP_VERSION
+#ifndef DOCTEST_CONFIG_USE_STD_HEADERS
+#define DOCTEST_CONFIG_USE_STD_HEADERS
+#endif
+#endif // _LIBCPP_VERSION
+
+#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
+#ifndef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#define DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif // DOCTEST_CONFIG_USE_STD_HEADERS
+
+#if defined(__has_builtin)
+#define DOCTEST_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define DOCTEST_HAS_BUILTIN(x) 0
+#endif // __has_builtin
+
+#endif // DOCTEST_PARTS_PUBLIC_CONFIG
+
+// =================================================================================================
+// == FEATURE DETECTION END ========================================================================
+// =================================================================================================
+#ifndef DOCTEST_PARTS_PUBLIC_UTILITY
+#define DOCTEST_PARTS_PUBLIC_UTILITY
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#define DOCTEST_DECLARE_INTERFACE(name)                                                                                \
+    virtual ~name();                                                                                                   \
+    name() = default;                                                                                                  \
+    name(const name &) = delete;                                                                                       \
+    name(name &&) = delete;                                                                                            \
+    name &operator=(const name &) = delete;                                                                            \
+    name &operator=(name &&) = delete;
+
+#define DOCTEST_DEFINE_INTERFACE(name) name::~name() = default;
+
+#if !defined(DOCTEST_COUNTER)
+#if DOCTEST_CLANG >= DOCTEST_COMPILER(22, 0, 0)
+#define DOCTEST_COUNTER __LINE__
+#elif defined(__COUNTER__)
+#define DOCTEST_COUNTER __COUNTER__
+#else
+#define DOCTEST_COUNTER __LINE__
+#endif
+#endif // defined(DOCTEST_COUNTER)
+
+// internal macros for string concatenation and anonymous variable name generation
+#define DOCTEST_CAT_IMPL(s1, s2) s1##s2
+#define DOCTEST_CAT(s1, s2) DOCTEST_CAT_IMPL(s1, s2)
+#define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, DOCTEST_COUNTER)
+
+#ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
+#define DOCTEST_REF_WRAP(x) x &
+#else // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
+#define DOCTEST_REF_WRAP(x) x
+#endif // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
+
+namespace doctest {
+namespace detail {
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-function")
+static DOCTEST_CONSTEXPR int consume(const int *, int) noexcept {
+    return 0;
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+} // namespace detail
+} // namespace doctest
+
+#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                                           \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                                  \
+    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_UTILITY
+#ifndef DOCTEST_PARTS_PUBLIC_DEBUGGER
+#define DOCTEST_PARTS_PUBLIC_DEBUGGER
+
+
+#ifndef DOCTEST_BREAK_INTO_DEBUGGER
+
+// should probably take a look at https://github.com/scottt/debugbreak
+#if DOCTEST_CLANG && DOCTEST_HAS_BUILTIN(__builtin_debugtrap)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __builtin_debugtrap()
+
+#elif defined(DOCTEST_PLATFORM_LINUX)
+#if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
+// Break at the location of the failing check if possible
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
+#else
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <signal.h>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+#define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
+#endif
+
+#elif defined(DOCTEST_PLATFORM_MAC)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
+#elif defined(__ppc__) || defined(__ppc64__)
+// https://www.cocoawithlove.com/2008/03/break-into-debugger.html
+#define DOCTEST_BREAK_INTO_DEBUGGER() /* NOLINTNEXTLINE(hicpp-no-assembler) */                                         \
+    __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" ::: "memory", "r0", "r3", "r4")
+#else
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
+#endif
+
+#elif DOCTEST_MSVC
+#define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
+
+#elif defined(__MINGW32__)
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wredundant-decls")
+extern "C" __declspec(dllimport) void __stdcall DebugBreak();
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+#define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
+#else // linux
+#define DOCTEST_BREAK_INTO_DEBUGGER() (static_cast<void>(0))
+#endif // linux
+#endif // DOCTEST_BREAK_INTO_DEBUGGER
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+DOCTEST_INTERFACE bool isDebuggerActive();
+} // namespace detail
+} // namespace doctest
+
+#endif
+
+#endif // DOCTEST_PARTS_PUBLIC_DEBUGGER
+#ifndef DOCTEST_PARTS_PUBLIC_STD_FWD
+#define DOCTEST_PARTS_PUBLIC_STD_FWD
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstddef>
+#include <ostream>
+#include <istream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+#else // DOCTEST_CONFIG_USE_STD_HEADERS
+
+// Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
+
+// NOLINTBEGIN(bugprone-std-namespace-modification, cert-dcl58-cpp)
+namespace std {
+typedef decltype(nullptr) nullptr_t;     // NOLINT(modernize-use-using)
+typedef decltype(sizeof(void *)) size_t; // NOLINT(modernize-use-using)
+template <class charT>
+struct char_traits;
+template <>
+struct char_traits<char>;
+template <class charT, class traits>
+class basic_ostream;                                    // NOLINT(fuchsia-virtual-inheritance)
+typedef basic_ostream<char, char_traits<char>> ostream; // NOLINT(modernize-use-using)
+template <class traits>
+// NOLINTNEXTLINE
+basic_ostream<char, traits> &operator<<(basic_ostream<char, traits> &, const char *);
+template <class charT, class traits>
+class basic_istream;
+typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
+template <class... Types>
+class tuple;
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+template <class Ty>
+class allocator;
+template <class Elem, class Traits, class Alloc>
+class basic_string;
+using string = basic_string<char, char_traits<char>, allocator<char>>;
+#endif // VS 2019
+} // namespace std
+// NOLINTEND(bugprone-std-namespace-modification, cert-dcl58-cpp)
+
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+#endif // DOCTEST_CONFIG_USE_STD_HEADERS
+
+namespace doctest {
+using std::size_t;
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_STD_FWD
+#ifndef DOCTEST_PARTS_PUBLIC_STD_TYPE_TRAITS
+#define DOCTEST_PARTS_PUBLIC_STD_TYPE_TRAITS
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <type_traits>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+
+namespace doctest {
+namespace detail {
+namespace types {
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+using namespace std;
+#else
+template <bool COND, typename T = void>
+struct enable_if {};
+
+template <typename T>
+struct enable_if<true, T> {
+    using type = T;
+};
+
+struct true_type {
+    static DOCTEST_CONSTEXPR bool value = true;
+};
+
+struct false_type {
+    static DOCTEST_CONSTEXPR bool value = false;
+};
+
+template <typename T>
+struct remove_reference {
+    using type = T;
+};
+
+template <typename T>
+struct remove_reference<T &> {
+    using type = T;
+};
+
+template <typename T>
+struct remove_reference<T &&> {
+    using type = T;
+};
+
+template <typename T, typename U>
+struct is_same : false_type {};
+
+template <typename T>
+struct is_same<T, T> : true_type {};
+
+template <typename T>
+struct is_rvalue_reference : false_type {};
+
+template <typename T>
+struct is_rvalue_reference<T &&> : true_type {};
+
+template <typename T>
+struct remove_const {
+    using type = T;
+};
+
+template <typename T>
+struct remove_const<const T> {
+    using type = T;
+};
+
+// Compiler intrinsics
+template <typename T>
+struct is_enum {
+    static DOCTEST_CONSTEXPR bool value = __is_enum(T);
+};
+
+template <typename T>
+struct underlying_type {
+    using type = __underlying_type(T);
+};
+
+template <typename T>
+struct is_pointer : false_type {};
+
+template <typename T>
+struct is_pointer<T *> : true_type {};
+
+template <typename T>
+struct is_array : false_type {};
+// NOLINTNEXTLINE(*-avoid-c-arrays)
+template <typename T, size_t SIZE>
+struct is_array<T[SIZE]> : true_type {};
+#endif
+
+#if !(defined(DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS) && (DOCTEST_CPLUSPLUS >= 201703L))
+template <typename... Unused>
+using void_t = void;
+#endif
+
+} // namespace types
+} // namespace detail
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_STD_TYPE_TRAITS
+#ifndef DOCTEST_PARTS_PUBLIC_STD_UTILITY
+#define DOCTEST_PARTS_PUBLIC_STD_UTILITY
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+
+// <utility>
+template <typename T>
+T &&declval();
+
+template <class T>
+DOCTEST_CONSTEXPR_FUNC T &&forward(typename types::remove_reference<T>::type &t) DOCTEST_NOEXCEPT {
+    return static_cast<T &&>(t);
+}
+
+template <class T>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+DOCTEST_CONSTEXPR_FUNC T &&forward(typename types::remove_reference<T>::type &&t) DOCTEST_NOEXCEPT {
+    return static_cast<T &&>(t);
+}
+
+template <typename T>
+struct deferred_false : types::false_type {};
+
+} // namespace detail
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_STD_UTILITY
+#ifndef DOCTEST_PARTS_PUBLIC_STRING
+#define DOCTEST_PARTS_PUBLIC_STRING
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+#ifndef DOCTEST_CONFIG_STRING_SIZE_TYPE
+#define DOCTEST_CONFIG_STRING_SIZE_TYPE unsigned
+#endif
+
+namespace detail {
+
+template <typename T, typename Enable = void>
+struct is_std_string : types::false_type {};
+
+template <typename T>
+struct is_std_string<
+    T,
+    typename types::enable_if<
+        types::is_same<decltype(declval<const T &>().c_str()), const char *>::value &&
+        types::is_same<decltype(declval<const T &>().size()), size_t>::value>::type> : types::true_type {};
+
+} // namespace detail
+
+// A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings
+// with length of up to 23 chars on the stack before going on the heap -
+// the last byte of the buffer is used for:
+// - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
+// - if small - capacity left before going on the heap - using the lowest 5 bits
+// - if small - 2 bits are left unused - the second and third highest ones
+// - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
+//              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
+// Idea taken from this lecture about the string implementation of facebook/folly - fbstring
+// https://www.youtube.com/watch?v=kPR8h4-qZdk
+// TODO:
+// - optimizations - like not deleting memory unnecessarily in operator= and etc.
+// - resize/reserve/clear
+// - replace
+// - back/front
+// - iterator stuff
+// - find & friends
+// - push_back/pop_back
+// - assign/insert/erase
+// - relational operators as free functions - taking const char* as one of the params
+class DOCTEST_INTERFACE String {
+public:
+    using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
+
+private:
+    static DOCTEST_CONSTEXPR size_type len = 24;
+    static DOCTEST_CONSTEXPR size_type last = len - 1;
+
+    struct view // len should be more than sizeof(view) - because of the final byte for flags
+    {
+        char *ptr;
+        size_type size;
+        size_type capacity;
+    };
+
+    union {
+        char buf[len]; // NOLINT(*-avoid-c-arrays)
+        view data;
+    };
+
+    char *allocate(size_type sz);
+
+    bool isOnStack() const noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+        return (buf[last] & 128) == 0;
+    }
+
+    void setOnHeap() noexcept;
+    void setLast(size_type in = last) noexcept;
+    void setSize(size_type sz) noexcept;
+
+    void copy(const String &other);
+
+public:
+    static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
+
+    String() noexcept;
+    ~String();
+
+    String(const char *in);
+    String(const char *in, size_type in_size);
+
+    String(std::istream &in, size_type in_size);
+
+    template <typename T, typename detail::types::enable_if<detail::is_std_string<T>::value, bool>::type = true>
+    String(const T &in)
+        : String(in.c_str(), static_cast<size_type>(in.size())) {}
+
+    String(const String &other);
+    String &operator=(const String &other);
+
+    String &operator+=(const String &other);
+
+    String(String &&other) noexcept;
+    String &operator=(String &&other) noexcept;
+
+    char operator[](size_type i) const;
+    char &operator[](size_type i);
+
+    // the only functions I'm willing to leave in the interface - available for inlining
+    const char *c_str() const {
+        return const_cast<String *>(this)->c_str(); // NOLINT
+    }
+
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+    char *c_str() {
+        if (isOnStack()) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            return reinterpret_cast<char *>(buf);
+        }
+        return data.ptr;
+    }
+    // NOLINTEND(cppcoreguidelines-pro-type-union-access)
+
+    size_type size() const;
+    size_type capacity() const;
+
+    String substr(size_type pos, size_type cnt = npos) &&;
+    String substr(size_type pos, size_type cnt = npos) const &;
+
+    size_type find(char ch, size_type pos = 0) const;
+    size_type rfind(char ch, size_type pos = npos) const;
+
+    int compare(const char *other, bool no_case = false) const;
+    int compare(const String &other, bool no_case = false) const;
+
+    friend DOCTEST_INTERFACE std::ostream &operator<<(std::ostream &s, const String &in);
+};
+
+DOCTEST_INTERFACE String operator+(const String &lhs, const String &rhs);
+
+DOCTEST_INTERFACE bool operator==(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator!=(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator<(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator>(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator<=(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator>=(const String &lhs, const String &rhs);
+
+namespace detail {
+
+// MSVS 2015 :(
+#if !DOCTEST_CLANG && defined(_MSC_VER) && _MSC_VER <= 1900
+template <typename T, typename = void>
+struct has_global_insertion_operator : types::false_type {};
+
+template <typename T>
+struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream &>(), declval<const T &>()), void())>
+    : types::true_type {};
+
+template <typename T, typename = void>
+struct has_insertion_operator {
+    static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value;
+};
+
+template <typename T, bool global>
+struct insert_hack;
+
+template <typename T>
+struct insert_hack<T, true> {
+    static void insert(std::ostream &os, const T &t) {
+        ::operator<<(os, t);
+    }
+};
+
+template <typename T>
+struct insert_hack<T, false> {
+    static void insert(std::ostream &os, const T &t) {
+        operator<<(os, t);
+    }
+};
+
+template <typename T>
+using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
+#else
+template <typename T, typename = void>
+struct has_insertion_operator : types::false_type {};
+#endif
+
+template <typename T>
+struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream &>(), declval<const T &>()), void())>
+    : types::true_type {};
+
+template <typename T>
+struct should_stringify_as_underlying_type {
+    static DOCTEST_CONSTEXPR bool value =
+        detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+};
+
+template <typename T, typename = void>
+struct is_pair : types::false_type {};
+
+template <typename T>
+struct is_pair<
+    T,
+    types::void_t<
+        typename T::first_type,
+        typename T::second_type,
+        decltype(declval<T>().first),
+        decltype(declval<T>().second)>> : types::true_type {};
+
+template <typename T, typename = void>
+struct is_container : types::false_type {};
+
+template <typename T>
+struct is_container<
+    T,
+    types::void_t<
+        typename T::value_type,
+        typename T::iterator,
+        decltype(declval<T>().begin()),
+        decltype(declval<T>().end())>> : types::true_type {};
+
+DOCTEST_INTERFACE std::ostream *tlssPush();
+DOCTEST_INTERFACE String tlssPop();
+
+template <bool C>
+struct StringMakerBase {
+    template <typename T>
+    static String convert(const DOCTEST_REF_WRAP(T)) {
+#ifdef DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES
+        static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
+#endif
+        return "{?}";
+    }
+};
+
+template <typename T, typename Enable = void>
+struct filldata;
+
+template <typename T>
+void filloss(std::ostream *stream, const T &in) {
+    filldata<T>::fill(stream, in);
+}
+
+template <typename T, size_t N>
+void filloss(std::ostream *stream, const T (&in)[N]) { // NOLINT(*-avoid-c-arrays)
+    // T[N], T(&)[N], T(&&)[N] have same behaviour.
+    // Hence remove reference.
+    filloss<typename types::remove_reference<decltype(in)>::type>(stream, in);
+}
+
+template <typename T>
+String toStream(const T &in) {
+    std::ostream *stream = tlssPush();
+    filloss(stream, in);
+    return tlssPop();
+}
+
+template <>
+struct StringMakerBase<true> {
+    template <typename T>
+    static String convert(const DOCTEST_REF_WRAP(T) in) {
+        return toStream(in);
+    }
+};
+
+} // namespace detail
+
+template <typename T>
+struct StringMaker
+    : public detail::StringMakerBase<
+          detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value ||
+          detail::types::is_array<T>::value || detail::is_pair<T>::value || detail::is_container<T>::value> {};
+
+#ifndef DOCTEST_STRINGIFY
+#ifdef DOCTEST_CONFIG_DOUBLE_STRINGIFY
+#define DOCTEST_STRINGIFY(...) toString(toString(__VA_ARGS__))
+#else
+#define DOCTEST_STRINGIFY(...) toString(__VA_ARGS__)
+#endif
+#endif
+
+template <typename T>
+String toString() {
+#if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
+    String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
+    String::size_type beginPos = ret.find('<');
+    return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
+#else
+    const String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
+    const String::size_type begin = ret.find('=') + 2;
+    return ret.substr(begin, ret.size() - begin - 1);
+#endif // Compiler
+}
+
+template <
+    typename T,
+    typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    return StringMaker<T>::convert(value);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+inline String &&toString(String &&in) {
+    return static_cast<String &&>(in);
+}
+
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+DOCTEST_INTERFACE String toString(const char *in);
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+DOCTEST_INTERFACE String toString(const std::string &in);
+#endif // VS 2019
+
+DOCTEST_INTERFACE String toString(const String &in);
+
+DOCTEST_INTERFACE String toString(std::nullptr_t);
+
+DOCTEST_INTERFACE String toString(bool in);
+
+DOCTEST_INTERFACE String toString(float in);
+DOCTEST_INTERFACE String toString(double in);
+DOCTEST_INTERFACE String toString(double long in);
+
+DOCTEST_INTERFACE String toString(char in);
+DOCTEST_INTERFACE String toString(char signed in);
+DOCTEST_INTERFACE String toString(char unsigned in);
+DOCTEST_INTERFACE String toString(short in);
+DOCTEST_INTERFACE String toString(short unsigned in);
+DOCTEST_INTERFACE String toString(signed in);
+DOCTEST_INTERFACE String toString(unsigned in);
+DOCTEST_INTERFACE String toString(long in);
+DOCTEST_INTERFACE String toString(long unsigned in);
+DOCTEST_INTERFACE String toString(long long in);
+DOCTEST_INTERFACE String toString(long long unsigned in);
+
+template <
+    typename T,
+    typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    using UT = typename detail::types::underlying_type<T>::type;
+    return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
+}
+
+namespace detail {
+template <typename T, typename Enable>
+struct filldata {
+    static void fill(std::ostream *stream, const T &in) {
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+        insert_hack_t<T>::insert(*stream, in);
+#else
+        operator<<(*stream, in);
+#endif // _MSV_VER
+    }
+};
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <typename T, size_t N>
+struct filldata<T[N]> {
+    static void fill(std::ostream *stream, const T (&in)[N]) {
+        *stream << "[";
+        for (size_t i = 0; i < N; i++) {
+            if (i != 0) {
+                *stream << ", ";
+            }
+            *stream << (DOCTEST_STRINGIFY(in[i]));
+        }
+        *stream << "]";
+    }
+};
+// NOLINTEND(*-avoid-c-arrays)
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+// Specialized since we don't want the terminating null byte!
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <size_t N>
+struct filldata<const char[N]> {
+    static void fill(std::ostream *stream, const char (&in)[N]) {
+        *stream << String(in, in[N - 1] ? N : N - 1);
+    } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+};
+// NOLINTEND(*-avoid-c-arrays)
+
+template <>
+struct filldata<const void *> {
+    DOCTEST_INTERFACE static void fill(std::ostream *stream, const void *in);
+};
+
+template <>
+struct filldata<const volatile void *> {
+    DOCTEST_INTERFACE static void fill(std::ostream *stream, const volatile void *in);
+};
+
+template <typename T>
+struct filldata<T *> {
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
+    static void fill(std::ostream *stream, const T *in) {
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+        filldata<const volatile void *>::fill(
+            stream,
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            reinterpret_cast<const volatile void *>(in)
+#else
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            *reinterpret_cast<const volatile void *const *>(&in)
+#endif // DOCTEST_GCC
+        );
+        DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    }
+};
+
+template <typename T>
+struct filldata<
+    T,
+    typename detail::types::enable_if<!detail::has_insertion_operator<T>::value && detail::is_pair<T>::value>::type> {
+    static void fill(std::ostream *stream, const T &in) {
+        *stream << "{" << DOCTEST_STRINGIFY(in.first) << ", " << DOCTEST_STRINGIFY(in.second) << "}";
+    }
+};
+
+template <typename T>
+struct filldata<
+    T,
+    typename detail::types::enable_if<
+        !detail::has_insertion_operator<T>::value && detail::is_container<T>::value>::type> {
+    static void fill(std::ostream *stream, const DOCTEST_REF_WRAP(T) in) {
+        *stream << "{";
+        for (auto it = in.begin(); it != in.end(); ++it) {
+            if (it != in.begin()) {
+                *stream << ", ";
+            }
+            *stream << DOCTEST_STRINGIFY(*it);
+        }
+        *stream << "}";
+    }
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+template <typename L, typename R>
+String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char *op, const DOCTEST_REF_WRAP(R) rhs) {
+    return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
+}
+#endif // DOCTEST_CONFIG_DISABLE
+} // namespace detail
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_STRING
+#ifndef DOCTEST_PARTS_PUBLIC_MATCHERS_CONTAINS
+#define DOCTEST_PARTS_PUBLIC_MATCHERS_CONTAINS
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+class DOCTEST_INTERFACE Contains {
+public:
+    explicit Contains(const String &string);
+
+    bool checkWith(const String &other) const;
+
+    String string;
+};
+
+DOCTEST_INTERFACE String toString(const Contains &in);
+
+DOCTEST_INTERFACE bool operator==(const String &lhs, const Contains &rhs);
+DOCTEST_INTERFACE bool operator==(const Contains &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator!=(const String &lhs, const Contains &rhs);
+DOCTEST_INTERFACE bool operator!=(const Contains &lhs, const String &rhs);
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_MATCHERS_CONTAINS
+#ifndef DOCTEST_PARTS_PUBLIC_MATCHERS_APPROX
+#define DOCTEST_PARTS_PUBLIC_MATCHERS_APPROX
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+struct DOCTEST_INTERFACE Approx {
+    Approx(double value);
+
+    Approx operator()(double value) const;
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    template <typename T>
+    explicit Approx(
+        const T &value,
+        typename detail::types::enable_if<std::is_constructible<double, T>::value>::type * = static_cast<T *>(nullptr)
+    ) {
+        *this = static_cast<double>(value);
+    }
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+
+    Approx &epsilon(double newEpsilon);
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    template <typename T>
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type epsilon(const T &newEpsilon) {
+        m_epsilon = static_cast<double>(newEpsilon);
+        return *this;
+    }
+#endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+
+    Approx &scale(double newScale);
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    template <typename T>
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type scale(const T &newScale) {
+        m_scale = static_cast<double>(newScale);
+        return *this;
+    }
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+
+    // clang-format off
+    DOCTEST_INTERFACE friend bool operator==(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator==(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator!=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator!=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator<=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator<=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator>=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator>=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator< (double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator< (const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator> (double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator> (const Approx &lhs, double rhs);
+    // clang-format on
+
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#define DOCTEST_APPROX_PREFIX                                                                                          \
+    template <typename T>                                                                                              \
+    friend typename std::enable_if<std::is_constructible<double, T>::value, bool>::type
+
+    // clang-format off
+    DOCTEST_APPROX_PREFIX operator==(const T &lhs, const Approx &rhs) { return operator==(static_cast<double>(lhs), rhs); }
+    DOCTEST_APPROX_PREFIX operator==(const Approx &lhs, const T &rhs) { return operator==(rhs, lhs); }
+    DOCTEST_APPROX_PREFIX operator!=(const T &lhs, const Approx &rhs) { return !operator==(lhs, rhs); }
+    DOCTEST_APPROX_PREFIX operator!=(const Approx &lhs, const T &rhs) { return !operator==(rhs, lhs); }
+    DOCTEST_APPROX_PREFIX operator<=(const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) < rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator<=(const Approx &lhs, const T &rhs) { return lhs.m_value < static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) > rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const Approx &lhs, const T &rhs) { return lhs.m_value > static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) < rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const Approx &lhs, const T &rhs) { return lhs.m_value < static_cast<double>(rhs) && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) > rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const Approx &lhs, const T &rhs) { return lhs.m_value > static_cast<double>(rhs) && lhs != rhs; }
+    // clang-format off
+#undef DOCTEST_APPROX_PREFIX
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+
+    double m_epsilon;
+    double m_scale;
+    double m_value;
+};
+
+DOCTEST_INTERFACE String toString(const Approx &in);
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_MATCHERS_APPROX
+#ifndef DOCTEST_PARTS_PUBLIC_MATCHERS_IS_NAN
+#define DOCTEST_PARTS_PUBLIC_MATCHERS_IS_NAN
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+template <typename F>
+struct DOCTEST_INTERFACE_DECL IsNaN {
+    F value;
+    bool flipped;
+    IsNaN(F f, bool flip = false)
+        : value(f), flipped(flip) {}
+
+    IsNaN<F> operator!() const {
+        return {value, !flipped};
+    }
+
+    operator bool() const;
+};
+
+#ifndef __MINGW32__
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<float>;
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<double>;
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<long double>;
+#endif
+
+DOCTEST_INTERFACE String toString(IsNaN<float> in);
+DOCTEST_INTERFACE String toString(IsNaN<double> in);
+DOCTEST_INTERFACE String toString(IsNaN<double long> in);
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_MATCHERS_IS_NAN
+#ifndef DOCTEST_PARTS_PUBLIC_CONTEXT_OPTIONS
+#define DOCTEST_PARTS_PUBLIC_CONTEXT_OPTIONS
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+struct DOCTEST_INTERFACE TestCase;
+} // namespace detail
+
+struct ContextOptions {
+    std::ostream *cout = nullptr; // stdout stream
+    String binary_name;           // the test binary name
+
+    const detail::TestCase *currentTest = nullptr;
+
+    // == parameters from the command line
+    String out;         // output filename
+    String order_by;    // how tests should be ordered
+    unsigned rand_seed; // the seed for rand ordering
+
+    unsigned first; // the first (matching) test to be executed
+    unsigned last;  // the last (matching) test to be executed
+
+    int abort_after;           // stop tests after this many failed assertions
+    int subcase_filter_levels; // apply the subcase filters for the first N levels
+
+    bool success;               // include successful assertions in output
+    bool case_sensitive;        // if filtering should be case sensitive
+    bool exit;                  // if the program should be exited after the tests are ran/whatever
+    bool duration;              // print the time duration of each test case
+    bool minimal;               // minimal console output (only test failures)
+    bool quiet;                 // no console output
+    bool no_throw;              // to skip exceptions-related assertion macros
+    bool no_exitcode;           // if the framework should return 0 as the exitcode
+    bool no_run;                // to not run the tests at all (can be done with an "*" exclude)
+    bool no_intro;              // to not print the intro of the framework
+    bool no_version;            // to not print the version of the framework
+    bool no_colors;             // if output to the console should be colorized
+    bool force_colors;          // forces the use of colors even when a tty cannot be detected
+    bool no_breaks;             // to not break into the debugger
+    bool no_skip;               // don't skip test cases which are marked to be skipped
+    bool gnu_file_line;         // if line numbers should be surrounded with :x: and not (x):
+    bool no_path_in_filenames;  // if the path to files should be removed from the output
+    String strip_file_prefixes; // remove the longest matching one of these prefixes from any file paths in the output
+    bool no_line_numbers;       // if source code line numbers should be omitted from the output
+    bool no_debug_output;       // no output in the debug console when a debugger is attached
+    bool no_skipped_summary;    // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+    bool no_time_in_output;     // omit any time/timestamps from output !!! UNDOCUMENTED !!!
+
+    bool help;             // to print the help
+    bool version;          // to print the version
+    bool count;            // if only the count of matching tests is to be retrieved
+    bool list_test_cases;  // to list all tests matching the filters
+    bool list_test_suites; // to list all suites matching the filters
+    bool list_reporters;   // lists all registered reporters
+};
+
+DOCTEST_INTERFACE const ContextOptions *getContextOptions();
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_CONTEXT_OPTIONS
+#ifndef DOCTEST_PARTS_PUBLIC_ASSERT_TYPE
+#define DOCTEST_PARTS_PUBLIC_ASSERT_TYPE
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+namespace assertType {
+enum Enum {
+    // macro traits
+
+    is_warn = 1,
+    is_check = 2 * is_warn,
+    is_require = 2 * is_check,
+
+    is_normal = 2 * is_require,
+    is_throws = 2 * is_normal,
+    is_throws_as = 2 * is_throws,
+    is_throws_with = 2 * is_throws_as,
+    is_nothrow = 2 * is_throws_with,
+
+    is_false = 2 * is_nothrow,
+    is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
+
+    is_eq = 2 * is_unary,
+    is_ne = 2 * is_eq,
+
+    is_lt = 2 * is_ne,
+    is_gt = 2 * is_lt,
+
+    is_ge = 2 * is_gt,
+    is_le = 2 * is_ge,
+
+    // macro types
+
+    DT_WARN = is_normal | is_warn,
+    DT_CHECK = is_normal | is_check,
+    DT_REQUIRE = is_normal | is_require,
+
+    DT_WARN_FALSE = is_normal | is_false | is_warn,
+    DT_CHECK_FALSE = is_normal | is_false | is_check,
+    DT_REQUIRE_FALSE = is_normal | is_false | is_require,
+
+    DT_WARN_THROWS = is_throws | is_warn,
+    DT_CHECK_THROWS = is_throws | is_check,
+    DT_REQUIRE_THROWS = is_throws | is_require,
+
+    DT_WARN_THROWS_AS = is_throws_as | is_warn,
+    DT_CHECK_THROWS_AS = is_throws_as | is_check,
+    DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
+
+    DT_WARN_THROWS_WITH = is_throws_with | is_warn,
+    DT_CHECK_THROWS_WITH = is_throws_with | is_check,
+    DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
+
+    DT_WARN_THROWS_WITH_AS = is_throws_with | is_throws_as | is_warn,
+    DT_CHECK_THROWS_WITH_AS = is_throws_with | is_throws_as | is_check,
+    DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
+
+    DT_WARN_NOTHROW = is_nothrow | is_warn,
+    DT_CHECK_NOTHROW = is_nothrow | is_check,
+    DT_REQUIRE_NOTHROW = is_nothrow | is_require,
+
+    DT_WARN_EQ = is_normal | is_eq | is_warn,
+    DT_CHECK_EQ = is_normal | is_eq | is_check,
+    DT_REQUIRE_EQ = is_normal | is_eq | is_require,
+
+    DT_WARN_NE = is_normal | is_ne | is_warn,
+    DT_CHECK_NE = is_normal | is_ne | is_check,
+    DT_REQUIRE_NE = is_normal | is_ne | is_require,
+
+    DT_WARN_GT = is_normal | is_gt | is_warn,
+    DT_CHECK_GT = is_normal | is_gt | is_check,
+    DT_REQUIRE_GT = is_normal | is_gt | is_require,
+
+    DT_WARN_LT = is_normal | is_lt | is_warn,
+    DT_CHECK_LT = is_normal | is_lt | is_check,
+    DT_REQUIRE_LT = is_normal | is_lt | is_require,
+
+    DT_WARN_GE = is_normal | is_ge | is_warn,
+    DT_CHECK_GE = is_normal | is_ge | is_check,
+    DT_REQUIRE_GE = is_normal | is_ge | is_require,
+
+    DT_WARN_LE = is_normal | is_le | is_warn,
+    DT_CHECK_LE = is_normal | is_le | is_check,
+    DT_REQUIRE_LE = is_normal | is_le | is_require,
+
+    DT_WARN_UNARY = is_normal | is_unary | is_warn,
+    DT_CHECK_UNARY = is_normal | is_unary | is_check,
+    DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
+
+    DT_WARN_UNARY_FALSE = is_normal | is_false | is_unary | is_warn,
+    DT_CHECK_UNARY_FALSE = is_normal | is_false | is_unary | is_check,
+    DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
+};
+} // namespace assertType
+
+DOCTEST_INTERFACE const char *assertString(assertType::Enum at);
+DOCTEST_INTERFACE const char *failureString(assertType::Enum at);
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_ASSERT_TYPE
+#ifndef DOCTEST_PARTS_PUBLIC_ASSERT_DATA
+#define DOCTEST_PARTS_PUBLIC_ASSERT_DATA
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+struct DOCTEST_INTERFACE TestCaseData;
+
+struct DOCTEST_INTERFACE AssertData {
+    // common - for all asserts
+    const TestCaseData *m_test_case;
+    assertType::Enum m_at;
+    const char *m_file;
+    int m_line;
+    const char *m_expr;
+    bool m_failed;
+
+    // exception-related - for all asserts
+    bool m_threw;
+    String m_exception;
+
+    // for normal asserts
+    String m_decomp;
+
+    // for specific exception-related asserts
+    bool m_threw_as;
+    const char *m_exception_type;
+
+    class DOCTEST_INTERFACE StringContains {
+    private:
+        Contains content;
+        bool isContains;
+
+    public:
+        StringContains(const String &str)
+            : content(str), isContains(false) {}
+
+        StringContains(Contains cntn)
+            : content(static_cast<Contains &&>(cntn)), isContains(true) {}
+
+        bool check(const String &str) {
+            return isContains ? (content == str) : (content.string == str);
+        }
+
+        operator const String &() const {
+            return content.string;
+        }
+
+        const char *c_str() const {
+            return content.string.c_str();
+        }
+    } m_exception_string;
+
+    AssertData(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type,
+        const StringContains &exception_string
+    );
+};
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_ASSERT_DATA
+#ifndef DOCTEST_PARTS_PUBLIC_ASSERT_COMPARATOR
+#define DOCTEST_PARTS_PUBLIC_ASSERT_COMPARATOR
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+// clang-format off
+template<class T>               struct decay_array       { using type = T; };
+template<class T, unsigned N>   struct decay_array<T[N]> { using type = T *; };
+template<class T>               struct decay_array<T[]>  { using type = T *; };
+
+template<class T>   struct not_char_pointer               { static DOCTEST_CONSTEXPR int value = 1; };
+template<>          struct not_char_pointer<char *>       { static DOCTEST_CONSTEXPR int value = 0; };
+template<>          struct not_char_pointer<const char *> { static DOCTEST_CONSTEXPR int value = 0; };
+
+template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
+// clang-format on
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+
+#ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#define DOCTEST_COMPARISON_RETURN_TYPE bool
+#else  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+// clang-format off
+#define DOCTEST_COMPARISON_RETURN_TYPE typename types::enable_if<can_use_op<L>::value || can_use_op<R>::value, bool>::type
+inline bool eq(const char *lhs, const char *rhs) { return String(lhs) == String(rhs); }
+inline bool ne(const char *lhs, const char *rhs) { return String(lhs) != String(rhs); }
+inline bool lt(const char *lhs, const char *rhs) { return String(lhs) <  String(rhs); }
+inline bool gt(const char *lhs, const char *rhs) { return String(lhs) >  String(rhs); }
+inline bool le(const char *lhs, const char *rhs) { return String(lhs) <= String(rhs); }
+inline bool ge(const char *lhs, const char *rhs) { return String(lhs) >= String(rhs); }
+// clang-format on
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+
+#define DOCTEST_RELATIONAL_OP(name, op)                                                                                \
+    template <typename L, typename R>                                                                                  \
+    DOCTEST_COMPARISON_RETURN_TYPE name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                \
+        return lhs op rhs;                                                                                             \
+    }
+
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
+
+#ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#define DOCTEST_CMP_EQ(l, r) l == r
+#define DOCTEST_CMP_NE(l, r) l != r
+#define DOCTEST_CMP_GT(l, r) l > r
+#define DOCTEST_CMP_LT(l, r) l < r
+#define DOCTEST_CMP_GE(l, r) l >= r
+#define DOCTEST_CMP_LE(l, r) l <= r
+#else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#define DOCTEST_CMP_EQ(l, r) eq(l, r)
+#define DOCTEST_CMP_NE(l, r) ne(l, r)
+#define DOCTEST_CMP_GT(l, r) gt(l, r)
+#define DOCTEST_CMP_LT(l, r) lt(l, r)
+#define DOCTEST_CMP_GE(l, r) ge(l, r)
+#define DOCTEST_CMP_LE(l, r) le(l, r)
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+
+namespace binaryAssertComparison {
+enum Enum { eq = 0, ne, gt, lt, ge, le };
+} // namespace binaryAssertComparison
+
+// clang-format off
+template <int, class L, class R>         struct RelationalComparator { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
+
+#define DOCTEST_BINARY_RELATIONAL_OP(n, op) \
+    template <class L, class R> struct RelationalComparator<n, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return op(lhs, rhs); } };
+// clang-format on
+
+DOCTEST_BINARY_RELATIONAL_OP(0, doctest::detail::eq)
+DOCTEST_BINARY_RELATIONAL_OP(1, doctest::detail::ne)
+DOCTEST_BINARY_RELATIONAL_OP(2, doctest::detail::gt)
+DOCTEST_BINARY_RELATIONAL_OP(3, doctest::detail::lt)
+DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
+DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_ASSERT_COMPARATOR
+#ifndef DOCTEST_PARTS_PUBLIC_ASSERT_RESULT
+#define DOCTEST_PARTS_PUBLIC_ASSERT_RESULT
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+// more checks could be added - like in Catch:
+// https://github.com/catchorg/Catch2/pull/1480/files
+// https://github.com/catchorg/Catch2/pull/1481/files
+#define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                                              \
+    template <typename R>                                                                                              \
+    rt &operator op(const R &) {                                                                                       \
+        static_assert(deferred_false<R>::value, "Expression Too Complex Please Rewrite As Binary Comparison!");        \
+        return *this;                                                                                                  \
+    }
+
+struct DOCTEST_INTERFACE Result { // NOLINT(*-member-init)
+    bool m_passed;
+    String m_decomp;
+
+    Result() = default; // TODO: Why do we need this? (To remove NOLINT)
+    Result(bool passed, const String &decomposition = String());
+
+    // forbidding some expressions based on this table:
+    // https://en.cppreference.com/w/cpp/language/operator_precedence
+    DOCTEST_FORBIT_EXPRESSION(Result, &)
+    DOCTEST_FORBIT_EXPRESSION(Result, ^)
+    DOCTEST_FORBIT_EXPRESSION(Result, |)
+    DOCTEST_FORBIT_EXPRESSION(Result, &&)
+    DOCTEST_FORBIT_EXPRESSION(Result, ||)
+    DOCTEST_FORBIT_EXPRESSION(Result, ==)
+    DOCTEST_FORBIT_EXPRESSION(Result, !=)
+    DOCTEST_FORBIT_EXPRESSION(Result, <)
+    DOCTEST_FORBIT_EXPRESSION(Result, >)
+    DOCTEST_FORBIT_EXPRESSION(Result, <=)
+    DOCTEST_FORBIT_EXPRESSION(Result, >=)
+    DOCTEST_FORBIT_EXPRESSION(Result, =)
+    DOCTEST_FORBIT_EXPRESSION(Result, +=)
+    DOCTEST_FORBIT_EXPRESSION(Result, -=)
+    DOCTEST_FORBIT_EXPRESSION(Result, *=)
+    DOCTEST_FORBIT_EXPRESSION(Result, /=)
+    DOCTEST_FORBIT_EXPRESSION(Result, %=)
+    DOCTEST_FORBIT_EXPRESSION(Result, <<=)
+    DOCTEST_FORBIT_EXPRESSION(Result, >>=)
+    DOCTEST_FORBIT_EXPRESSION(Result, &=)
+    DOCTEST_FORBIT_EXPRESSION(Result, ^=)
+    DOCTEST_FORBIT_EXPRESSION(Result, |=)
+};
+
+struct DOCTEST_INTERFACE ResultBuilder : public AssertData {
+    ResultBuilder(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type = "",
+        const String &exception_string = ""
+    );
+
+    ResultBuilder(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type,
+        const Contains &exception_string
+    );
+
+    void setResult(const Result &res);
+
+    template <int comparison, typename L, typename R>
+    DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {
+        m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+        if (m_failed || getContextOptions()->success) {
+            m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+        }
+        return !m_failed;
+    }
+
+    template <typename L>
+    DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
+        m_failed = !val;
+
+        if (m_at & assertType::is_false) {
+            m_failed = !m_failed;
+        }
+
+        if (m_failed || getContextOptions()->success) {
+            m_decomp = (DOCTEST_STRINGIFY(val));
+        }
+
+        return !m_failed;
+    }
+
+    void translateException();
+
+    bool log();
+    void react() const;
+};
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_ASSERT_RESULT
+#ifndef DOCTEST_PARTS_PUBLIC_ASSERT_EXPRESSION
+#define DOCTEST_PARTS_PUBLIC_ASSERT_EXPRESSION
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
+#endif
+
+// This will check if there is any way it could find a operator like member or friend and uses it.
+// If not it doesn't find the operator or if the operator at global scope is defined after
+// this template, the template won't be instantiated due to SFINAE. Once the template is not
+// instantiated it can look for global operator using normal conversions.
+#ifdef __NVCC__
+#define SFINAE_OP(ret, op) ret
+#else
+#define SFINAE_OP(ret, op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()), ret{})
+#endif
+
+#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                                                  \
+    /* NOLINTBEGIN(cppcoreguidelines-missing-std-forward) */                                                           \
+    template <typename R>                                                                                              \
+    DOCTEST_NOINLINE SFINAE_OP(Result, op) operator op(R &&rhs) {                                                      \
+        bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs));                 \
+        if (m_at & assertType::is_false)                                                                               \
+            res = !res;                                                                                                \
+        if (!res || doctest::getContextOptions()->success)                                                             \
+            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                                                 \
+        return Result(res);                                                                                            \
+    }                                                                                                                  \
+    /* NOLINTEND(cppcoreguidelines-missing-std-forward) */
+
+#ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
+
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+// https://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
+DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
+// DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in
+// operation
+
+#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+
+template <typename L>
+struct Expression_lhs {
+    L lhs;
+    assertType::Enum m_at;
+
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    explicit Expression_lhs(L &&in, assertType::Enum at)
+        : lhs(static_cast<L &&>(in)), m_at(at) {}
+
+    DOCTEST_NOINLINE operator Result() {
+        // this is needed only for MSVC 2015
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
+        bool res = static_cast<bool>(lhs);            // NOLINT(bugprone-non-zero-enum-to-bool-conversion)
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        if (m_at & assertType::is_false) {
+            res = !res;
+        }
+
+        if (!res || getContextOptions()->success) {
+            return {res, (DOCTEST_STRINGIFY(lhs))};
+        }
+        return {res};
+    }
+
+    /* This is required for user-defined conversions from Expression_lhs to L */
+    operator L() const {
+        return lhs;
+    }
+
+    // clang-format off
+    DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ)
+    DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(!=, " != ", DOCTEST_CMP_NE)
+    DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>,  " >  ", DOCTEST_CMP_GT)
+    DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<,  " <  ", DOCTEST_CMP_LT)
+    DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>=, " >= ", DOCTEST_CMP_GE)
+    DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE)
+    // clang-format on
+
+    // forbidding some expressions based on this table:
+    // https://en.cppreference.com/w/cpp/language/operator_precedence
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &&)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ||)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, =)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, +=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, -=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, *=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, /=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, %=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
+    // these 2 are unfortunate because they should be allowed - they have higher precedence over the
+    // comparisons, but the ExpressionDecomposer class uses the left shift operator to capture the
+    // left operand of the binary expression...
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
+    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
+};
+
+#ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+
+#if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#endif
+
+struct DOCTEST_INTERFACE ExpressionDecomposer {
+    assertType::Enum m_at;
+
+    ExpressionDecomposer(assertType::Enum at);
+
+    // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator
+    // precedence table) but then there will be warnings from GCC about "-Wparentheses" and since
+    // "_Pragma()" is problematic this will stay for now...
+    // https://github.com/catchorg/Catch2/issues/870
+    // https://github.com/catchorg/Catch2/issues/565
+    template <typename L>
+    Expression_lhs<const L &&>
+    operator<<(const L &&operand) { // bitfields bind to universal ref but not const rvalue ref
+        return Expression_lhs<const L &&>(static_cast<const L &&>(operand), m_at);
+    }
+
+    template <
+        typename L,
+        typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value, void>::type * = nullptr>
+    Expression_lhs<const L &> operator<<(const L &operand) {
+        return Expression_lhs<const L &>(operand, m_at);
+    }
+};
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_ASSERT_EXPRESSION
+#ifndef DOCTEST_PARTS_PUBLIC_COLOR
+#define DOCTEST_PARTS_PUBLIC_COLOR
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+namespace Color {
+enum Enum { // NOLINT(cert-int09-c, readability-enum-initial-value)
+    None = 0,
+    White,
+    Red,
+    Green,
+    Blue,
+    Cyan,
+    Yellow,
+    Grey,
+
+    Bright = 0x10,
+
+    BrightRed = Bright | Red,
+    BrightGreen = Bright | Green,
+    LightGrey = Bright | Grey,
+    BrightWhite = Bright | White
+};
+
+DOCTEST_INTERFACE std::ostream &operator<<(std::ostream &s, Color::Enum code);
+} // namespace Color
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_COLOR
+#ifndef DOCTEST_PARTS_PUBLIC_SUBCASE
+#define DOCTEST_PARTS_PUBLIC_SUBCASE
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+struct DOCTEST_INTERFACE SubcaseSignature {
+    String m_name;
+    const char *m_file;
+    int m_line;
+
+    bool operator==(const SubcaseSignature &other) const;
+    bool operator<(const SubcaseSignature &other) const;
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+struct DOCTEST_INTERFACE Subcase {
+    SubcaseSignature m_signature;
+    bool m_entered = false;
+
+    Subcase(const String &name, const char *file, int line);
+    Subcase(const Subcase &) = delete;
+    Subcase(Subcase &&) = delete;
+    Subcase &operator=(const Subcase &) = delete;
+    Subcase &operator=(Subcase &&) = delete;
+    ~Subcase();
+
+    operator bool() const;
+
+private:
+    bool checkFilters();
+};
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_SUBCASE
+#ifndef DOCTEST_PARTS_PUBLIC_TEST_SUITE
+#define DOCTEST_PARTS_PUBLIC_TEST_SUITE
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+struct DOCTEST_INTERFACE TestSuite {
+    const char *m_test_suite = nullptr;
+    const char *m_description = nullptr;
+    bool m_skip = false;
+    bool m_no_breaks = false;
+    bool m_no_output = false;
+    bool m_may_fail = false;
+    bool m_should_fail = false;
+    int m_expected_failures = 0;
+    double m_timeout = 0;
+
+    TestSuite &operator*(const char *in) noexcept;
+
+    template <typename T>
+    TestSuite &operator*(const T &in) noexcept {
+        in.fill(*this);
+        return *this;
+    }
+};
+
+// forward declarations of functions used by the macros
+DOCTEST_INTERFACE int setTestSuite(const TestSuite &ts) noexcept;
+
+} // namespace detail
+
+} // namespace doctest
+
+// in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
+// introduces an anonymous namespace in which getCurrentTestSuite gets overridden
+namespace doctest_detail_test_suite_ns {
+DOCTEST_INTERFACE doctest::detail::TestSuite &getCurrentTestSuite() noexcept;
+
+// this is here to clear the 'current test suite' for the current translation unit - at the top
+DOCTEST_GLOBAL_NO_WARNINGS(/* NOLINT(cert-err58-cpp) */
+                           DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_),
+                           doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")
+)
+
+} // namespace doctest_detail_test_suite_ns
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_TEST_SUITE
+#ifndef DOCTEST_PARTS_PUBLIC_TEST_CASE
+#define DOCTEST_PARTS_PUBLIC_TEST_CASE
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+struct DOCTEST_INTERFACE TestCaseData {
+    String m_file;            // the file in which the test was registered (using String - see #350)
+    unsigned m_line;          // the line where the test was registered
+    const char *m_name;       // name of the test case
+    const char *m_test_suite; // the test suite in which the test was added
+    const char *m_description;
+    bool m_skip;
+    bool m_no_breaks;
+    bool m_no_output;
+    bool m_may_fail;
+    bool m_should_fail;
+    int m_expected_failures;
+    double m_timeout;
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+
+using funcType = void (*)();
+
+struct DOCTEST_INTERFACE TestCase : public TestCaseData {
+    funcType m_test; // a function pointer to the test case
+
+    String m_type;      // for templated test cases - gets appended to the real name
+    int m_template_id;  // an ID used to distinguish between the different versions of a templated
+                        // test case
+    String m_full_name; // contains the name (only for templated test cases!) + the template type
+
+    TestCase(
+        funcType test,
+        const char *file,
+        unsigned line,
+        const TestSuite &test_suite,
+        const String &type = String(),
+        int template_id = -1
+    ) noexcept;
+
+    TestCase(const TestCase &other) noexcept;
+    TestCase(TestCase &&) = delete;
+
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+    TestCase &operator=(const TestCase &other) noexcept;
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+    TestCase &operator=(TestCase &&) = delete;
+
+    TestCase &operator*(const char *in) noexcept;
+
+    template <typename T>
+    TestCase &operator*(const T &in) noexcept {
+        in.fill(*this);
+        return *this;
+    }
+
+    bool operator<(const TestCase &other) const noexcept;
+
+    ~TestCase() = default;
+};
+
+// forward declarations of functions used by the macros
+DOCTEST_INTERFACE int regTest(const TestCase &tc) noexcept;
+
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_TEST_CASE
+#ifndef DOCTEST_PARTS_PUBLIC_DECORATORS
+#define DOCTEST_PARTS_PUBLIC_DECORATORS
+
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                                      \
+    struct name {                                                                                                      \
+        type data;                                                                                                     \
+        name(type in = def) noexcept                                                                                   \
+            : data(in) {}                                                                                              \
+        void fill(detail::TestCase &state) const noexcept {                                                            \
+            state.DOCTEST_CAT(m_, name) = data;                                                                        \
+        }                                                                                                              \
+        void fill(detail::TestSuite &state) const noexcept {                                                           \
+            state.DOCTEST_CAT(m_, name) = data;                                                                        \
+        }                                                                                                              \
+    }
+
+DOCTEST_DEFINE_DECORATOR(test_suite, const char *, "");
+DOCTEST_DEFINE_DECORATOR(description, const char *, "");
+DOCTEST_DEFINE_DECORATOR(skip, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
+DOCTEST_DEFINE_DECORATOR(timeout, double, 0);
+DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
+DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
+DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+#endif // DOCTEST_PARTS_PUBLIC_DECORATORS
+#ifndef DOCTEST_PARTS_PUBLIC_EXCEPTION_TRANSLATOR
+#define DOCTEST_PARTS_PUBLIC_EXCEPTION_TRANSLATOR
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+struct DOCTEST_INTERFACE IExceptionTranslator {
+    DOCTEST_DECLARE_INTERFACE(IExceptionTranslator)
+    virtual bool translate(String &) const = 0;
+};
+
+template <typename T>
+class ExceptionTranslator : public IExceptionTranslator {
+public:
+    explicit ExceptionTranslator(String (*translateFunction)(T)) noexcept
+        : m_translateFunction(translateFunction) {}
+
+    bool translate(String &res) const override {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        try {
+            throw;
+        } catch (const T &ex) {
+            res = m_translateFunction(ex);
+            return true;
+        } catch (...) {}        // NOLINT(bugprone-empty-catch)
+#endif                          // DOCTEST_CONFIG_NO_EXCEPTIONS
+        static_cast<void>(res); // to silence -Wunused-parameter
+        return false;
+    }
+
+private:
+    String (*m_translateFunction)(T);
+};
+
+DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator *et) noexcept;
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace detail
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+template <typename T>
+int registerExceptionTranslator(String (*translateFunction)(T)) noexcept {
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
+    static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    detail::registerExceptionTranslatorImpl(&exceptionTranslator);
+    return 0;
+}
+
+#else // DOCTEST_CONFIG_DISABLE
+
+template <typename T>
+int registerExceptionTranslator(String (*)(T)) noexcept {
+    return 0;
+}
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_EXCEPTION_TRANSLATOR
+#ifndef DOCTEST_PARTS_PUBLIC_CONTEXT_SCOPE
+#define DOCTEST_PARTS_PUBLIC_CONTEXT_SCOPE
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+struct DOCTEST_INTERFACE IContextScope {
+    DOCTEST_DECLARE_INTERFACE(IContextScope)
+    virtual void stringify(std::ostream *) const = 0;
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+
+// ContextScope base class used to allow implementing methods of ContextScope
+// that don't depend on the template parameter in doctest.cpp.
+struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+    ContextScopeBase(const ContextScopeBase &) = delete;
+
+    ContextScopeBase &operator=(const ContextScopeBase &) = delete;
+    ContextScopeBase &operator=(ContextScopeBase &&) = delete;
+
+    ~ContextScopeBase() override = default;
+
+protected:
+    ContextScopeBase();
+    ContextScopeBase(ContextScopeBase &&other) noexcept;
+
+    void destroy();
+    bool need_to_destroy{true};
+};
+
+template <typename L>
+class ContextScope : public ContextScopeBase {
+    L lambda_;
+
+public:
+    explicit ContextScope(const L &lambda)
+        : lambda_(lambda) {}
+
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    explicit ContextScope(L &&lambda)
+        : lambda_(static_cast<L &&>(lambda)) {}
+
+    ContextScope(const ContextScope &) = delete;
+    ContextScope(ContextScope &&) noexcept = default;
+
+    ContextScope &operator=(const ContextScope &) = delete;
+    ContextScope &operator=(ContextScope &&) = delete;
+
+    void stringify(std::ostream *s) const override {
+        lambda_(s);
+    }
+
+    ~ContextScope() override {
+        if (need_to_destroy) {
+            destroy();
+        }
+    }
+};
+
+template <typename L>
+ContextScope<L> MakeContextScope(const L &lambda) {
+    return ContextScope<L>(lambda);
+}
+
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_CONTEXT_SCOPE
+#ifndef DOCTEST_PARTS_PUBLIC_ASSERT_MESSAGE
+#define DOCTEST_PARTS_PUBLIC_ASSERT_MESSAGE
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+struct DOCTEST_INTERFACE MessageData {
+    String m_string;
+    const char *m_file;
+    int m_line;
+    assertType::Enum m_severity;
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+
+struct DOCTEST_INTERFACE MessageBuilder : public MessageData {
+    std::ostream *m_stream;
+    bool logged = false;
+
+    MessageBuilder(const char *file, int line, assertType::Enum severity);
+
+    MessageBuilder(const MessageBuilder &) = delete;
+    MessageBuilder(MessageBuilder &&) = delete;
+
+    MessageBuilder &operator=(const MessageBuilder &) = delete;
+    MessageBuilder &operator=(MessageBuilder &&) = delete;
+
+    ~MessageBuilder() noexcept(false);
+
+    // the preferred way of chaining parameters for stringification
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+    template <typename T>
+    MessageBuilder &operator,(const T &in) {
+        *m_stream << (DOCTEST_STRINGIFY(in));
+        return *this;
+    }
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+    // kept here just for backwards-compatibility - the comma operator should be preferred now
+    template <typename T>
+    MessageBuilder &operator<<(const T &in) {
+        return this->operator,(in);
+    }
+
+    // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
+    // the `,` operator will be called last which is not what we want and thus the `*` operator
+    // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
+    // an operator of the MessageBuilder class is called first before the rest of the parameters
+    template <typename T>
+    MessageBuilder &operator*(const T &in) {
+        return this->operator,(in);
+    }
+
+    bool log();
+    void react();
+};
+
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_ASSERT_MESSAGE
+#ifndef DOCTEST_PARTS_PUBLIC_PATH
+#define DOCTEST_PARTS_PUBLIC_PATH
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+DOCTEST_INTERFACE const char *skipPathFromFilename(const char *file);
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_PATH
+#ifndef DOCTEST_PARTS_PUBLIC_EXCEPTIONS
+#define DOCTEST_PARTS_PUBLIC_EXCEPTIONS
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+struct DOCTEST_INTERFACE TestFailureException {};
+
+DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+DOCTEST_NORETURN
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+DOCTEST_INTERFACE void throwException();
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_EXCEPTIONS
+#ifndef DOCTEST_PARTS_PUBLIC_CONTEXT
+#define DOCTEST_PARTS_PUBLIC_CONTEXT
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+DOCTEST_INTERFACE extern bool is_running_in_test;
+
+namespace detail {
+using assert_handler = void (*)(const AssertData &);
+struct ContextState;
+} // namespace detail
+
+class DOCTEST_INTERFACE Context {
+    detail::ContextState *p;
+
+    void parseArgs(int argc, const char *const *argv, bool withDefaults = false);
+
+public:
+    explicit Context(int argc = 0, const char *const *argv = nullptr);
+
+    Context(const Context &) = delete;
+    Context(Context &&) = delete;
+
+    Context &operator=(const Context &) = delete;
+    Context &operator=(Context &&) = delete;
+
+    ~Context(); // NOLINT(performance-trivially-destructible)
+
+    void applyCommandLine(int argc, const char *const *argv);
+
+    void addFilter(const char *filter, const char *value);
+    void clearFilters();
+    void setOption(const char *option, bool value);
+    void setOption(const char *option, int value);
+    void setOption(const char *option, const char *value);
+
+    bool shouldExit();
+
+    void setAsDefaultForAssertsOutOfTestCases();
+
+    void setAssertHandler(detail::assert_handler ah);
+
+    void setCout(std::ostream *out);
+
+    int run();
+};
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_CONTEXT
+#ifndef DOCTEST_PARTS_PUBLIC_ASSERT_HANDLER
+#define DOCTEST_PARTS_PUBLIC_ASSERT_HANDLER
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData &ad);
+
+DOCTEST_INTERFACE bool
+decomp_assert(assertType::Enum at, const char *file, int line, const char *expr, const Result &result);
+
+#define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                                            \
+    do { /* NOLINT(cppcoreguidelines-avoid-do-while) */                                                                \
+        if (!is_running_in_test) {                                                                                     \
+            if (failed) {                                                                                              \
+                ResultBuilder rb(at, file, line, expr);                                                                \
+                rb.m_failed = failed;                                                                                  \
+                rb.m_decomp = decomp;                                                                                  \
+                failed_out_of_a_testing_context(rb);                                                                   \
+                if (isDebuggerActive() && !getContextOptions()->no_breaks)                                             \
+                    DOCTEST_BREAK_INTO_DEBUGGER();                                                                     \
+                if (checkIfShouldThrow(at))                                                                            \
+                    throwException();                                                                                  \
+            }                                                                                                          \
+            return !failed;                                                                                            \
+        }                                                                                                              \
+    } while (false)
+
+#define DOCTEST_ASSERT_IN_TESTS(decomp)                                                                                \
+    ResultBuilder rb(at, file, line, expr);                                                                            \
+    rb.m_failed = failed;                                                                                              \
+    if (rb.m_failed || getContextOptions()->success)                                                                   \
+        rb.m_decomp = decomp;                                                                                          \
+    if (rb.log())                                                                                                      \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                                                 \
+    if (rb.m_failed && checkIfShouldThrow(at))                                                                         \
+    throwException()
+
+template <int comparison, typename L, typename R>
+DOCTEST_NOINLINE bool binary_assert(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const DOCTEST_REF_WRAP(L) lhs,
+    const DOCTEST_REF_WRAP(R) rhs
+) {
+    const bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+    DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+    return !failed;
+}
+
+template <typename L>
+DOCTEST_NOINLINE bool
+unary_assert(assertType::Enum at, const char *file, int line, const char *expr, const DOCTEST_REF_WRAP(L) val) {
+    bool failed = !val;
+
+    if (at & assertType::is_false)
+        failed = !failed;
+
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS((DOCTEST_STRINGIFY(val)));
+    DOCTEST_ASSERT_IN_TESTS((DOCTEST_STRINGIFY(val)));
+    return !failed;
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_ASSERT_HANDLER
+#ifndef DOCTEST_PARTS_PUBLIC_REPORTER
+#define DOCTEST_PARTS_PUBLIC_REPORTER
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+namespace doctest {
+
+namespace TestCaseFailureReason {
+enum Enum {
+    None = 0,
+    AssertFailure = 1,              // an assertion has failed in the test case
+    Exception = 2,                  // test case threw an exception
+    Crash = 4,                      // a crash...
+    TooManyFailedAsserts = 8,       // the abort-after option
+    Timeout = 16,                   // see the timeout decorator
+    ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
+    ShouldHaveFailedAndDid = 64,    // see the should_fail decorator
+    DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
+    FailedExactlyNumTimes = 256,    // see the expected_failures decorator
+    CouldHaveFailedAndDid = 512     // see the may_fail decorator
+};
+} // namespace TestCaseFailureReason
+
+struct DOCTEST_INTERFACE CurrentTestCaseStats {
+    int numAssertsCurrentTest;
+    int numAssertsFailedCurrentTest;
+    double seconds;
+    int failure_flags; // use TestCaseFailureReason::Enum
+    bool testCaseSuccess;
+};
+
+struct DOCTEST_INTERFACE TestCaseException {
+    String error_string;
+    bool is_crash;
+};
+
+struct DOCTEST_INTERFACE TestRunStats {
+    unsigned numTestCases;
+    unsigned numTestCasesPassingFilters;
+    unsigned numTestSuitesPassingFilters;
+    unsigned numTestCasesFailed;
+    int numAsserts;
+    int numAssertsFailed;
+};
+
+struct QueryData {
+    const TestRunStats *run_stats = nullptr;
+    const TestCaseData **data = nullptr;
+    unsigned num_data = 0;
+};
+
+struct DOCTEST_INTERFACE IReporter {
+    // The constructor has to accept "const ContextOptions&" as a single argument
+    // which has most of the options for the run + a pointer to the stdout stream
+    // Reporter(const ContextOptions& in)
+
+    // called when a query should be reported (listing test cases, printing the version, etc.)
+    virtual void report_query(const QueryData &) = 0;
+
+    // called when the whole test run starts
+    virtual void test_run_start() = 0;
+    // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+    virtual void test_run_end(const TestRunStats &) = 0;
+
+    // called when a test case is started (safe to cache a pointer to the input)
+    virtual void test_case_start(const TestCaseData &) = 0;
+    // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+    virtual void test_case_reenter(const TestCaseData &) = 0;
+    // called when a test case has ended
+    virtual void test_case_end(const CurrentTestCaseStats &) = 0;
+
+    // called when an exception is thrown from the test case (or it crashes)
+    virtual void test_case_exception(const TestCaseException &) = 0;
+
+    // called whenever a subcase is entered (don't cache pointers to the input)
+    virtual void subcase_start(const SubcaseSignature &) = 0;
+    // called whenever a subcase is exited (don't cache pointers to the input)
+    virtual void subcase_end() = 0;
+
+    // called for each assert (don't cache pointers to the input)
+    virtual void log_assert(const AssertData &) = 0;
+    // called for each message (don't cache pointers to the input)
+    virtual void log_message(const MessageData &) = 0;
+
+    // called when a test case is skipped either because it doesn't pass the filters,
+    // has a skip decorator or isn't in the execution range (between first and last)
+    // (safe to cache a pointer to the input)
+    virtual void test_case_skipped(const TestCaseData &) = 0;
+
+    DOCTEST_DECLARE_INTERFACE(IReporter)
+
+    // can obtain all currently active contexts and stringify them if one wishes to do so
+    static int get_num_active_contexts();
+    static const IContextScope *const *get_active_contexts();
+
+    // can iterate through contexts which have been stringified automatically
+    // in their destructors when an exception has been thrown
+    static int get_num_stringified_contexts();
+    static const String *get_stringified_contexts();
+};
+
+namespace detail {
+using reporterCreatorFunc = IReporter *(*)(const ContextOptions &);
+
+DOCTEST_INTERFACE void
+registerReporterImpl(const char *name, int prio, reporterCreatorFunc c, bool isReporter) noexcept;
+
+template <typename Reporter>
+IReporter *reporterCreator(const ContextOptions &o) {
+    return new Reporter(o);
+}
+} // namespace detail
+
+template <typename Reporter>
+int registerReporter(const char *name, int priority, bool isReporter) noexcept {
+    detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
+    return 0;
+}
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_REPORTER
+#ifndef DOCTEST_PARTS_PUBLIC_GENERATOR
+#define DOCTEST_PARTS_PUBLIC_GENERATOR
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace doctest {
+namespace detail {
+
+DOCTEST_INTERFACE size_t acquireGeneratorDecisionIndex(size_t count);
+
+template <typename T, typename... Rest>
+T acquireGeneratorValue(T first, Rest... rest) {
+    const T values[] = {first, static_cast<T>(rest)...};
+    const size_t idx = acquireGeneratorDecisionIndex(1 + sizeof...(Rest));
+    return values[idx];
+}
+
+} // namespace detail
+} // namespace doctest
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_GENERATOR
+#ifndef DOCTEST_PARTS_PUBLIC_MACROS
+#define DOCTEST_PARTS_PUBLIC_MACROS
+
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace doctest {
+namespace detail {
+template <typename T>
+int instantiationHelper(const T &) noexcept {
+    return 0;
+}
+
+} // namespace detail
+} // namespace doctest
+#endif // DOCTEST_CONFIG_DISABLE
+
+#ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
+#define DOCTEST_FUNC_EMPTY [] { return false; }()
+#else
+#define DOCTEST_FUNC_EMPTY (void)0
+#endif
+
+// if registering is not disabled
+#ifndef DOCTEST_CONFIG_DISABLE
+
+#ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
+#define DOCTEST_FUNC_SCOPE_BEGIN [&]
+#define DOCTEST_FUNC_SCOPE_END ()
+#define DOCTEST_FUNC_SCOPE_RET(v) return v
+#else
+#define DOCTEST_FUNC_SCOPE_BEGIN do /* NOLINT(cppcoreguidelines-avoid-do-while)*/
+#define DOCTEST_FUNC_SCOPE_END while (false)
+#define DOCTEST_FUNC_SCOPE_RET(v) (void)0
+#endif
+
+// common code in asserts - for convenience
+#define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                                             \
+    if (b.log())                                                                                                       \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                                                 \
+    b.react();                                                                                                         \
+    DOCTEST_FUNC_SCOPE_RET(!b.m_failed)
+
+#ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#define DOCTEST_WRAP_IN_TRY(x) x;
+#else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#define DOCTEST_WRAP_IN_TRY(x)                                                                                         \
+    try {                                                                                                              \
+        x;                                                                                                             \
+    } catch (...) { DOCTEST_RB.translateException(); }
+#endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+
+#ifdef DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
+#define DOCTEST_CAST_TO_VOID(...)                                                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                                           \
+    static_cast<void>(__VA_ARGS__);                                                                                    \
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+#else // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
+#define DOCTEST_CAST_TO_VOID(...) __VA_ARGS__;
+#endif // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
+
+// registers the test by initializing a dummy var with a function
+#define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                                        \
+    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(                                                                          \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */                                                             \
+        doctest::detail::regTest(                                                                                      \
+            doctest::detail::TestCase(f, __FILE__, __LINE__, doctest_detail_test_suite_ns::getCurrentTestSuite()) *    \
+            decorators                                                                                                 \
+        )                                                                                                              \
+    )
+
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                                         \
+    namespace { /* NOLINT */                                                                                           \
+    struct der : public base {                                                                                         \
+        void f();                                                                                                      \
+    };                                                                                                                 \
+    static DOCTEST_INLINE_NOINLINE void func() {                                                                       \
+        der v;                                                                                                         \
+        v.f();                                                                                                         \
+    }                                                                                                                  \
+    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                                         \
+    }                                                                                                                  \
+    DOCTEST_INLINE_NOINLINE void der::f() // NOLINT(misc-definitions-in-headers)
+
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                                            \
+    static void f();                                                                                                   \
+    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, f, decorators)                                                            \
+    static void f()
+
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(f, proxy, decorators)                                            \
+    static doctest::detail::funcType proxy() {                                                                         \
+        return f;                                                                                                      \
+    }                                                                                                                  \
+    DOCTEST_REGISTER_FUNCTION(inline, proxy(), decorators)                                                             \
+    static void f()
+
+// for registering tests
+#define DOCTEST_TEST_CASE(decorators)                                                                                  \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
+
+// for registering tests in classes - requires C++17 for inline variables!
+#if DOCTEST_CPLUSPLUS >= 201703L
+#define DOCTEST_TEST_CASE_CLASS(decorators)                                                                            \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(                                                                     \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), DOCTEST_ANONYMOUS(DOCTEST_ANON_PROXY_), decorators                      \
+    )
+#else // DOCTEST_TEST_CASE_CLASS
+#define DOCTEST_TEST_CASE_CLASS(...) TEST_CASES_CAN_BE_REGISTERED_IN_CLASSES_ONLY_IN_CPP17_MODE_OR_WITH_VS_2017_OR_NEWER
+#endif // DOCTEST_TEST_CASE_CLASS
+
+// for registering tests with a fixture
+#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                                       \
+    DOCTEST_IMPLEMENT_FIXTURE(                                                                                         \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), c, DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators                   \
+    )
+
+// for converting types to strings without the <typeinfo> header and demangling
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...)                                                                            \
+    namespace doctest {                                                                                                \
+    template <>                                                                                                        \
+    inline String toString<__VA_ARGS__>() {                                                                            \
+        return str;                                                                                                    \
+    }                                                                                                                  \
+    }                                                                                                                  \
+    static_assert(true, "")
+
+#define DOCTEST_TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING_AS(#__VA_ARGS__, __VA_ARGS__)
+
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, iter, func)                                                     \
+    template <typename T>                                                                                              \
+    static void func();                                                                                                \
+    namespace { /* NOLINT */                                                                                           \
+    template <typename Tuple>                                                                                          \
+    struct iter;                                                                                                       \
+    template <typename Type, typename... Rest>                                                                         \
+    struct iter<std::tuple<Type, Rest...>> {                                                                           \
+        iter(const char *file, unsigned line, int index) noexcept {                                                    \
+            doctest::detail::regTest(                                                                                  \
+                doctest::detail::TestCase(                                                                             \
+                    func<Type>,                                                                                        \
+                    file,                                                                                              \
+                    line,                                                                                              \
+                    doctest_detail_test_suite_ns::getCurrentTestSuite(),                                               \
+                    doctest::toString<Type>(),                                                                         \
+                    int(line) * 1000 + index                                                                           \
+                ) *                                                                                                    \
+                dec                                                                                                    \
+            );                                                                                                         \
+            iter<std::tuple<Rest...>>(file, line, index + 1);                                                          \
+        }                                                                                                              \
+    };                                                                                                                 \
+    template <>                                                                                                        \
+    struct iter<std::tuple<>> {                                                                                        \
+        iter(const char *, unsigned, int) {}                                                                           \
+    };                                                                                                                 \
+    }                                                                                                                  \
+    template <typename T>                                                                                              \
+    static void func()
+
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                                                  \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(id, ITERATOR), DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
+
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                                     \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */                 \
+        doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR) < __VA_ARGS__ > (__FILE__, __LINE__, 0))        \
+    )
+
+#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                                     \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>)     \
+    static_assert(true, "")
+
+#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                                      \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)                 \
+    static_assert(true, "")
+
+#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                                             \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(anon, ITERATOR), anon);                                 \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(anon, anon, std::tuple<__VA_ARGS__>)                                   \
+    template <typename T>                                                                                              \
+    static void anon()
+
+#define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                                        \
+    DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)
+
+// for subcases
+#define DOCTEST_SUBCASE(name)                                                                                          \
+    if (const doctest::detail::Subcase &DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =                      \
+            doctest::detail::Subcase(name, __FILE__, __LINE__))
+
+// for generating value-parameterized test inputs
+#define DOCTEST_GENERATE(...) doctest::detail::acquireGeneratorValue(__VA_ARGS__)
+
+// for grouping tests in test suites by using code blocks
+#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                                                   \
+    namespace ns_name {                                                                                                \
+    namespace doctest_detail_test_suite_ns {                                                                           \
+    static DOCTEST_NOINLINE doctest::detail::TestSuite &getCurrentTestSuite() noexcept {                               \
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                                                  \
+        DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                                            \
+        DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-field-initializers")                                         \
+        static doctest::detail::TestSuite data{};                                                                      \
+        static bool inited = false;                                                                                    \
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                                              \
+        DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                                             \
+        DOCTEST_GCC_SUPPRESS_WARNING_POP                                                                               \
+        if (!inited) {                                                                                                 \
+            data *decorators;                                                                                          \
+            inited = true;                                                                                             \
+        }                                                                                                              \
+        return data;                                                                                                   \
+    }                                                                                                                  \
+    }                                                                                                                  \
+    }                                                                                                                  \
+    namespace ns_name
+
+#define DOCTEST_TEST_SUITE(decorators) DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(DOCTEST_ANON_SUITE_))
+
+// for starting a testsuite block
+#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                                           \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                                             \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators)                                       \
+    )                                                                                                                  \
+    static_assert(true, "")
+
+// for ending a testsuite block
+#define DOCTEST_TEST_SUITE_END                                                                                         \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                                             \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")                                               \
+    )                                                                                                                  \
+    using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
+
+// for registering exception translators
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                                          \
+    inline doctest::String translatorName(signature);                                                                  \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_VAR_), /* NOLINT(cert-err58-cpp) */                                  \
+        doctest::registerExceptionTranslator(translatorName)                                                           \
+    )                                                                                                                  \
+    doctest::String translatorName(signature)
+
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                                               \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), signature)
+
+// for registering reporters
+#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_VAR_), /* NOLINT(cert-err58-cpp) */                                    \
+        doctest::registerReporter<reporter>(name, priority, true)                                                      \
+    )                                                                                                                  \
+    static_assert(true, "")
+
+// for registering listeners
+#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_VAR_), /* NOLINT(cert-err58-cpp) */                                    \
+        doctest::registerReporter<reporter>(name, priority, false)                                                     \
+    )                                                                                                                  \
+    static_assert(true, "")
+
+#define DOCTEST_INFO(...)                                                                                              \
+    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_MB_), DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_), __VA_ARGS__)
+
+#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                                                        \
+    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope([&](std::ostream *s_name) {           \
+        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn);                     \
+        mb_name.m_stream = s_name;                                                                                     \
+        mb_name *__VA_ARGS__;                                                                                          \
+    })
+
+#define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := ", x)
+
+#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                                                 \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                                     \
+        mb *__VA_ARGS__;                                                                                               \
+        if (mb.log())                                                                                                  \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                                             \
+        mb.react();                                                                                                    \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...)                                                                        \
+    DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...)                                                                     \
+    DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_AT(file, line, ...)                                                                           \
+    DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+
+#define DOCTEST_MESSAGE(...) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, __VA_ARGS__)
+#define DOCTEST_FAIL_CHECK(...) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, __VA_ARGS__)
+#define DOCTEST_FAIL(...) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, __VA_ARGS__)
+
+#define DOCTEST_TO_LVALUE(...) __VA_ARGS__ // Not removed to keep backwards compatibility.
+
+#ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+#define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                                      \
+    /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                                      \
+    doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__);     \
+    DOCTEST_WRAP_IN_TRY(                                                                                               \
+        DOCTEST_RB.setResult(doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) << __VA_ARGS__)   \
+    ) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                                    \
+    DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB)                                                                        \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                                          \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                                                  \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(__VA_ARGS__))      \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                                         \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                                      \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
+
+#else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+// necessary for <ASSERT>_MESSAGE
+#define DOCTEST_ASSERT_IMPLEMENT_2 DOCTEST_ASSERT_IMPLEMENT_1
+
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                                      \
+    doctest::detail::decomp_assert(                                                                                    \
+        doctest::assertType::assert_type,                                                                              \
+        __FILE__,                                                                                                      \
+        __LINE__,                                                                                                      \
+        #__VA_ARGS__,                                                                                                  \
+        doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) << __VA_ARGS__                         \
+    ) DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                                            \
+    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(                               \
+        doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__                                \
+    )
+
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                                         \
+    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
+
+#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+#define DOCTEST_WARN(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_WARN, __VA_ARGS__)
+#define DOCTEST_CHECK(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_CHECK, __VA_ARGS__)
+#define DOCTEST_REQUIRE(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_REQUIRE, __VA_ARGS__)
+#define DOCTEST_WARN_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_WARN_FALSE, __VA_ARGS__)
+#define DOCTEST_CHECK_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_CHECK_FALSE, __VA_ARGS__)
+#define DOCTEST_REQUIRE_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_REQUIRE_FALSE, __VA_ARGS__)
+
+// clang-format off
+#define DOCTEST_WARN_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
+// clang-format on
+
+#define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, eq, __VA_ARGS__)
+#define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, eq, __VA_ARGS__)
+#define DOCTEST_REQUIRE_EQ(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, eq, __VA_ARGS__)
+#define DOCTEST_WARN_NE(...) DOCTEST_BINARY_ASSERT(DT_WARN_NE, ne, __VA_ARGS__)
+#define DOCTEST_CHECK_NE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, ne, __VA_ARGS__)
+#define DOCTEST_REQUIRE_NE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, ne, __VA_ARGS__)
+#define DOCTEST_WARN_GT(...) DOCTEST_BINARY_ASSERT(DT_WARN_GT, gt, __VA_ARGS__)
+#define DOCTEST_CHECK_GT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, gt, __VA_ARGS__)
+#define DOCTEST_REQUIRE_GT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, gt, __VA_ARGS__)
+#define DOCTEST_WARN_LT(...) DOCTEST_BINARY_ASSERT(DT_WARN_LT, lt, __VA_ARGS__)
+#define DOCTEST_CHECK_LT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, lt, __VA_ARGS__)
+#define DOCTEST_REQUIRE_LT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, lt, __VA_ARGS__)
+#define DOCTEST_WARN_GE(...) DOCTEST_BINARY_ASSERT(DT_WARN_GE, ge, __VA_ARGS__)
+#define DOCTEST_CHECK_GE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, ge, __VA_ARGS__)
+#define DOCTEST_REQUIRE_GE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, ge, __VA_ARGS__)
+#define DOCTEST_WARN_LE(...) DOCTEST_BINARY_ASSERT(DT_WARN_LE, le, __VA_ARGS__)
+#define DOCTEST_CHECK_LE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, le, __VA_ARGS__)
+#define DOCTEST_REQUIRE_LE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, le, __VA_ARGS__)
+
+#define DOCTEST_WARN_UNARY(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, __VA_ARGS__)
+#define DOCTEST_CHECK_UNARY(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, __VA_ARGS__)
+#define DOCTEST_REQUIRE_UNARY(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, __VA_ARGS__)
+#define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, __VA_ARGS__)
+#define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, __VA_ARGS__)
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, __VA_ARGS__)
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                                      \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        if (!doctest::getContextOptions()->no_throw) {                                                                 \
+            doctest::detail::ResultBuilder DOCTEST_RB(                                                                 \
+                doctest::assertType::assert_type, __FILE__, __LINE__, #expr, #__VA_ARGS__, message                     \
+            );                                                                                                         \
+            try {                                                                                                      \
+                DOCTEST_CAST_TO_VOID(expr)                                                                             \
+            } catch (const typename doctest::detail::types::remove_const<                                              \
+                     typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type &) {                  \
+                DOCTEST_RB.translateException();                                                                       \
+                DOCTEST_RB.m_threw_as = true;                                                                          \
+            } catch (...) { DOCTEST_RB.translateException(); }                                                         \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                               \
+        } else { /* NOLINT(*-else-after-return) */                                                                     \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        if (!doctest::getContextOptions()->no_throw) {                                                                 \
+            doctest::detail::ResultBuilder DOCTEST_RB(                                                                 \
+                doctest::assertType::assert_type, __FILE__, __LINE__, expr_str, "", __VA_ARGS__                        \
+            );                                                                                                         \
+            try {                                                                                                      \
+                DOCTEST_CAST_TO_VOID(expr)                                                                             \
+            } catch (...) { DOCTEST_RB.translateException(); }                                                         \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                               \
+        } else { /* NOLINT(*-else-after-return) */                                                                     \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                                       \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        try {                                                                                                          \
+            DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                                          \
+        } catch (...) { DOCTEST_RB.translateException(); }                                                             \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
+
+// clang-format off
+#define DOCTEST_WARN_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_WARN_THROWS, "")
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_CHECK_THROWS, "")
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_REQUIRE_THROWS, "")
+
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_AS, "", __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_AS, "", __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_AS, "", __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_WARN_THROWS_WITH, __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_CHECK_THROWS_WITH, __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_REQUIRE_THROWS_WITH, __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_WITH_AS, message, __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_WITH_AS, message, __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_WITH_AS, message, __VA_ARGS__)
+
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_WARN_NOTHROW, __VA_ARGS__)
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_CHECK_NOTHROW, __VA_ARGS__)
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_REQUIRE_NOTHROW, __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+// clang-format on
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+// =================================================================================================
+// == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
+// == THIS CAN BE ENABLED BY DEFINING DOCTEST_CONFIG_DISABLE GLOBALLY!                            ==
+// =================================================================================================
+#else // DOCTEST_CONFIG_DISABLE
+
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                                               \
+    namespace /* NOLINT */ {                                                                                           \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
+    struct der : public base {                                                                                         \
+        void f();                                                                                                      \
+    };                                                                                                                 \
+    }                                                                                                                  \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
+    inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
+
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                                                  \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
+    static inline void f()
+
+// for registering tests
+#define DOCTEST_TEST_CASE(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for registering tests in classes
+#define DOCTEST_TEST_CASE_CLASS(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for registering tests with a fixture
+#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                                             \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), x, DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for converting types to strings without the <typeinfo> header and demangling
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...) static_assert(true, "")
+#define DOCTEST_TYPE_TO_STRING(...) static_assert(true, "")
+
+// for typed tests
+#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                                    \
+    template <typename type>                                                                                           \
+    inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
+
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                                              \
+    template <typename type>                                                                                           \
+    inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
+
+#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...) static_assert(true, "")
+#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...) static_assert(true, "")
+
+// for subcases
+#define DOCTEST_SUBCASE(name)
+
+// for generating value-parameterized test inputs
+#define DOCTEST_GENERATE_IMPL(first, ...) (first)
+#define DOCTEST_GENERATE(...) DOCTEST_GENERATE_IMPL(__VA_ARGS__, DOCTEST_EMPTY)
+
+// for a testsuite block
+#define DOCTEST_TEST_SUITE(name) namespace // NOLINT
+
+// for starting a testsuite block
+#define DOCTEST_TEST_SUITE_BEGIN(name) static_assert(true, "")
+
+// for ending a testsuite block
+#define DOCTEST_TEST_SUITE_END using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
+
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                                               \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
+    static inline doctest::String DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_)(signature)
+
+#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+
+#define DOCTEST_INFO(...) (static_cast<void>(0))
+#define DOCTEST_CAPTURE(x) (static_cast<void>(0))
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_ADD_FAIL_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_MESSAGE(...) (static_cast<void>(0))
+#define DOCTEST_FAIL_CHECK(...) (static_cast<void>(0))
+#define DOCTEST_FAIL(...) (static_cast<void>(0))
+
+#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED) && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
+
+#define DOCTEST_WARN(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_CHECK(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_REQUIRE(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_WARN_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_CHECK_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_FALSE(...) [&] { return !(__VA_ARGS__); }()
+
+#define DOCTEST_WARN_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_CHECK_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+
+namespace doctest {
+namespace detail {
+#define DOCTEST_RELATIONAL_OP(name, op)                                                                                \
+    template <typename L, typename R>                                                                                  \
+    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                                          \
+        return lhs op rhs;                                                                                             \
+    }
+
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
+} // namespace detail
+} // namespace doctest
+
+#define DOCTEST_WARN_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_CHECK_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_WARN_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_CHECK_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_WARN_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_CHECK_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_WARN_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_CHECK_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_WARN_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_CHECK_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_WARN_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_CHECK_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_WARN_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_CHECK_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_REQUIRE_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_WARN_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_CHECK_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_WARN_THROWS_WITH(expr, with, ...)                                                                      \
+    [] {                                                                                                               \
+        static_assert(false, "Exception translation is not available when doctest is disabled.");                      \
+        return false;                                                                                                  \
+    }()
+#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+
+// clang-format off
+#define DOCTEST_WARN_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_CHECK_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_REQUIRE_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_WARN_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_WARN_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_CHECK_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_REQUIRE_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+// clang-format on
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#else // DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED
+
+#define DOCTEST_WARN(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_FALSE(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_LE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_LE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_LE(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_WARN_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#endif // DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+#ifdef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#define DOCTEST_EXCEPTION_EMPTY_FUNC DOCTEST_FUNC_EMPTY
+#else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#define DOCTEST_EXCEPTION_EMPTY_FUNC                                                                                   \
+    [] {                                                                                                               \
+        static_assert(                                                                                                 \
+            false,                                                                                                     \
+            "Exceptions are disabled! "                                                                                \
+            "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want "                                       \
+            "to compile with exceptions disabled."                                                                     \
+        );                                                                                                             \
+        return false;                                                                                                  \
+    }()
+
+#undef DOCTEST_REQUIRE
+#undef DOCTEST_REQUIRE_FALSE
+#undef DOCTEST_REQUIRE_MESSAGE
+#undef DOCTEST_REQUIRE_FALSE_MESSAGE
+#undef DOCTEST_REQUIRE_EQ
+#undef DOCTEST_REQUIRE_NE
+#undef DOCTEST_REQUIRE_GT
+#undef DOCTEST_REQUIRE_LT
+#undef DOCTEST_REQUIRE_GE
+#undef DOCTEST_REQUIRE_LE
+#undef DOCTEST_REQUIRE_UNARY
+#undef DOCTEST_REQUIRE_UNARY_FALSE
+
+#define DOCTEST_REQUIRE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_FALSE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_MESSAGE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_FALSE_MESSAGE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_EQ DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_GT DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_LT DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_GE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_LE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_UNARY DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_UNARY_FALSE DOCTEST_EXCEPTION_EMPTY_FUNC
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+
+#define DOCTEST_WARN_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+// KEPT FOR BACKWARDS COMPATIBILITY - FORWARDING TO THE RIGHT MACROS
+#define DOCTEST_FAST_WARN_EQ DOCTEST_WARN_EQ
+#define DOCTEST_FAST_CHECK_EQ DOCTEST_CHECK_EQ
+#define DOCTEST_FAST_REQUIRE_EQ DOCTEST_REQUIRE_EQ
+#define DOCTEST_FAST_WARN_NE DOCTEST_WARN_NE
+#define DOCTEST_FAST_CHECK_NE DOCTEST_CHECK_NE
+#define DOCTEST_FAST_REQUIRE_NE DOCTEST_REQUIRE_NE
+#define DOCTEST_FAST_WARN_GT DOCTEST_WARN_GT
+#define DOCTEST_FAST_CHECK_GT DOCTEST_CHECK_GT
+#define DOCTEST_FAST_REQUIRE_GT DOCTEST_REQUIRE_GT
+#define DOCTEST_FAST_WARN_LT DOCTEST_WARN_LT
+#define DOCTEST_FAST_CHECK_LT DOCTEST_CHECK_LT
+#define DOCTEST_FAST_REQUIRE_LT DOCTEST_REQUIRE_LT
+#define DOCTEST_FAST_WARN_GE DOCTEST_WARN_GE
+#define DOCTEST_FAST_CHECK_GE DOCTEST_CHECK_GE
+#define DOCTEST_FAST_REQUIRE_GE DOCTEST_REQUIRE_GE
+#define DOCTEST_FAST_WARN_LE DOCTEST_WARN_LE
+#define DOCTEST_FAST_CHECK_LE DOCTEST_CHECK_LE
+#define DOCTEST_FAST_REQUIRE_LE DOCTEST_REQUIRE_LE
+
+#define DOCTEST_FAST_WARN_UNARY DOCTEST_WARN_UNARY
+#define DOCTEST_FAST_CHECK_UNARY DOCTEST_CHECK_UNARY
+#define DOCTEST_FAST_REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
+#define DOCTEST_FAST_WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
+#define DOCTEST_FAST_CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
+#define DOCTEST_FAST_REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
+
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, __VA_ARGS__)
+
+// BDD style macros
+// clang-format off
+#define DOCTEST_SCENARIO(name)                                        DOCTEST_TEST_CASE("  Scenario: " name)
+#define DOCTEST_SCENARIO_CLASS(name)                            DOCTEST_TEST_CASE_CLASS("  Scenario: " name)
+#define DOCTEST_SCENARIO_METHOD(x, name)                   DOCTEST_TEST_CASE_FIXTURE(x, "  Scenario: " name)
+#define DOCTEST_SCENARIO_TEMPLATE(name, T, ...)              DOCTEST_TEST_CASE_TEMPLATE("  Scenario: " name, T, __VA_ARGS__)
+#define DOCTEST_SCENARIO_TEMPLATE_DEFINE(name, T, id) DOCTEST_TEST_CASE_TEMPLATE_DEFINE("  Scenario: " name, T, id)
+
+#define DOCTEST_GIVEN(name)     DOCTEST_SUBCASE("   Given: " name)
+#define DOCTEST_AND_GIVEN(name) DOCTEST_SUBCASE("     And: " name)
+#define DOCTEST_WHEN(name)      DOCTEST_SUBCASE("    When: " name)
+#define DOCTEST_AND_WHEN(name)  DOCTEST_SUBCASE("     And: " name)
+#define DOCTEST_THEN(name)      DOCTEST_SUBCASE("    Then: " name)
+#define DOCTEST_AND_THEN(name)  DOCTEST_SUBCASE("     And: " name)
+// clang-format on
+
+// == SHORT VERSIONS OF THE MACROS
+#ifndef DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
+
+#define TEST_CASE(name) DOCTEST_TEST_CASE(name)
+#define TEST_CASE_CLASS(name) DOCTEST_TEST_CASE_CLASS(name)
+#define TEST_CASE_FIXTURE(x, name) DOCTEST_TEST_CASE_FIXTURE(x, name)
+#define TYPE_TO_STRING_AS(str, ...) DOCTEST_TYPE_TO_STRING_AS(str, __VA_ARGS__)
+#define TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING(__VA_ARGS__)
+#define TEST_CASE_TEMPLATE(name, T, ...) DOCTEST_TEST_CASE_TEMPLATE(name, T, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_DEFINE(name, T, id) DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, T, id)
+#define TEST_CASE_TEMPLATE_INVOKE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_APPLY(id, ...) DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, __VA_ARGS__)
+#define SUBCASE(name) DOCTEST_SUBCASE(name)
+#define GENERATE(...) DOCTEST_GENERATE(__VA_ARGS__)
+#define TEST_SUITE(decorators) DOCTEST_TEST_SUITE(decorators)
+#define TEST_SUITE_BEGIN(name) DOCTEST_TEST_SUITE_BEGIN(name)
+#define TEST_SUITE_END DOCTEST_TEST_SUITE_END
+#define REGISTER_EXCEPTION_TRANSLATOR(signature) DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)
+#define REGISTER_REPORTER(name, priority, reporter) DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define REGISTER_LISTENER(name, priority, reporter) DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+#define INFO(...) DOCTEST_INFO(__VA_ARGS__)
+#define CAPTURE(x) DOCTEST_CAPTURE(x)
+#define ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_MESSAGE_AT(file, line, __VA_ARGS__)
+#define ADD_FAIL_CHECK_AT(file, line, ...) DOCTEST_ADD_FAIL_CHECK_AT(file, line, __VA_ARGS__)
+#define ADD_FAIL_AT(file, line, ...) DOCTEST_ADD_FAIL_AT(file, line, __VA_ARGS__)
+#define MESSAGE(...) DOCTEST_MESSAGE(__VA_ARGS__)
+#define FAIL_CHECK(...) DOCTEST_FAIL_CHECK(__VA_ARGS__)
+#define FAIL(...) DOCTEST_FAIL(__VA_ARGS__)
+#define TO_LVALUE(...) DOCTEST_TO_LVALUE(__VA_ARGS__)
+
+#define WARN(...) DOCTEST_WARN(__VA_ARGS__)
+#define WARN_FALSE(...) DOCTEST_WARN_FALSE(__VA_ARGS__)
+#define WARN_THROWS(...) DOCTEST_WARN_THROWS(__VA_ARGS__)
+#define WARN_THROWS_AS(expr, ...) DOCTEST_WARN_THROWS_AS(expr, __VA_ARGS__)
+#define WARN_THROWS_WITH(expr, ...) DOCTEST_WARN_THROWS_WITH(expr, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_WARN_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define WARN_NOTHROW(...) DOCTEST_WARN_NOTHROW(__VA_ARGS__)
+#define CHECK(...) DOCTEST_CHECK(__VA_ARGS__)
+#define CHECK_FALSE(...) DOCTEST_CHECK_FALSE(__VA_ARGS__)
+#define CHECK_THROWS(...) DOCTEST_CHECK_THROWS(__VA_ARGS__)
+#define CHECK_THROWS_AS(expr, ...) DOCTEST_CHECK_THROWS_AS(expr, __VA_ARGS__)
+#define CHECK_THROWS_WITH(expr, ...) DOCTEST_CHECK_THROWS_WITH(expr, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define CHECK_NOTHROW(...) DOCTEST_CHECK_NOTHROW(__VA_ARGS__)
+#define REQUIRE(...) DOCTEST_REQUIRE(__VA_ARGS__)
+#define REQUIRE_FALSE(...) DOCTEST_REQUIRE_FALSE(__VA_ARGS__)
+#define REQUIRE_THROWS(...) DOCTEST_REQUIRE_THROWS(__VA_ARGS__)
+#define REQUIRE_THROWS_AS(expr, ...) DOCTEST_REQUIRE_THROWS_AS(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH(expr, ...) DOCTEST_REQUIRE_THROWS_WITH(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define REQUIRE_NOTHROW(...) DOCTEST_REQUIRE_NOTHROW(__VA_ARGS__)
+
+// clang-format off
+#define WARN_MESSAGE(cond, ...) DOCTEST_WARN_MESSAGE(cond, __VA_ARGS__)
+#define WARN_FALSE_MESSAGE(cond, ...) DOCTEST_WARN_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define WARN_THROWS_MESSAGE(expr, ...) DOCTEST_WARN_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_WARN_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+#define CHECK_MESSAGE(cond, ...) DOCTEST_CHECK_MESSAGE(cond, __VA_ARGS__)
+#define CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_CHECK_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_CHECK_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_CHECK_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+#define REQUIRE_MESSAGE(cond, ...) DOCTEST_REQUIRE_MESSAGE(cond, __VA_ARGS__)
+#define REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_REQUIRE_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_REQUIRE_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+// clang-format on
+
+#define SCENARIO(name) DOCTEST_SCENARIO(name)
+#define SCENARIO_METHOD(x, name) DOCTEST_SCENARIO_METHOD(x, name)
+#define SCENARIO_CLASS(name) DOCTEST_SCENARIO_CLASS(name)
+#define SCENARIO_TEMPLATE(name, T, ...) DOCTEST_SCENARIO_TEMPLATE(name, T, __VA_ARGS__)
+#define SCENARIO_TEMPLATE_DEFINE(name, T, id) DOCTEST_SCENARIO_TEMPLATE_DEFINE(name, T, id)
+#define GIVEN(name) DOCTEST_GIVEN(name)
+#define AND_GIVEN(name) DOCTEST_AND_GIVEN(name)
+#define WHEN(name) DOCTEST_WHEN(name)
+#define AND_WHEN(name) DOCTEST_AND_WHEN(name)
+#define THEN(name) DOCTEST_THEN(name)
+#define AND_THEN(name) DOCTEST_AND_THEN(name)
+
+#define WARN_EQ(...) DOCTEST_WARN_EQ(__VA_ARGS__)
+#define CHECK_EQ(...) DOCTEST_CHECK_EQ(__VA_ARGS__)
+#define REQUIRE_EQ(...) DOCTEST_REQUIRE_EQ(__VA_ARGS__)
+#define WARN_NE(...) DOCTEST_WARN_NE(__VA_ARGS__)
+#define CHECK_NE(...) DOCTEST_CHECK_NE(__VA_ARGS__)
+#define REQUIRE_NE(...) DOCTEST_REQUIRE_NE(__VA_ARGS__)
+#define WARN_GT(...) DOCTEST_WARN_GT(__VA_ARGS__)
+#define CHECK_GT(...) DOCTEST_CHECK_GT(__VA_ARGS__)
+#define REQUIRE_GT(...) DOCTEST_REQUIRE_GT(__VA_ARGS__)
+#define WARN_LT(...) DOCTEST_WARN_LT(__VA_ARGS__)
+#define CHECK_LT(...) DOCTEST_CHECK_LT(__VA_ARGS__)
+#define REQUIRE_LT(...) DOCTEST_REQUIRE_LT(__VA_ARGS__)
+#define WARN_GE(...) DOCTEST_WARN_GE(__VA_ARGS__)
+#define CHECK_GE(...) DOCTEST_CHECK_GE(__VA_ARGS__)
+#define REQUIRE_GE(...) DOCTEST_REQUIRE_GE(__VA_ARGS__)
+#define WARN_LE(...) DOCTEST_WARN_LE(__VA_ARGS__)
+#define CHECK_LE(...) DOCTEST_CHECK_LE(__VA_ARGS__)
+#define REQUIRE_LE(...) DOCTEST_REQUIRE_LE(__VA_ARGS__)
+#define WARN_UNARY(...) DOCTEST_WARN_UNARY(__VA_ARGS__)
+#define CHECK_UNARY(...) DOCTEST_CHECK_UNARY(__VA_ARGS__)
+#define REQUIRE_UNARY(...) DOCTEST_REQUIRE_UNARY(__VA_ARGS__)
+#define WARN_UNARY_FALSE(...) DOCTEST_WARN_UNARY_FALSE(__VA_ARGS__)
+#define CHECK_UNARY_FALSE(...) DOCTEST_CHECK_UNARY_FALSE(__VA_ARGS__)
+#define REQUIRE_UNARY_FALSE(...) DOCTEST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
+
+// KEPT FOR BACKWARDS COMPATIBILITY
+#define FAST_WARN_EQ(...) DOCTEST_FAST_WARN_EQ(__VA_ARGS__)
+#define FAST_CHECK_EQ(...) DOCTEST_FAST_CHECK_EQ(__VA_ARGS__)
+#define FAST_REQUIRE_EQ(...) DOCTEST_FAST_REQUIRE_EQ(__VA_ARGS__)
+#define FAST_WARN_NE(...) DOCTEST_FAST_WARN_NE(__VA_ARGS__)
+#define FAST_CHECK_NE(...) DOCTEST_FAST_CHECK_NE(__VA_ARGS__)
+#define FAST_REQUIRE_NE(...) DOCTEST_FAST_REQUIRE_NE(__VA_ARGS__)
+#define FAST_WARN_GT(...) DOCTEST_FAST_WARN_GT(__VA_ARGS__)
+#define FAST_CHECK_GT(...) DOCTEST_FAST_CHECK_GT(__VA_ARGS__)
+#define FAST_REQUIRE_GT(...) DOCTEST_FAST_REQUIRE_GT(__VA_ARGS__)
+#define FAST_WARN_LT(...) DOCTEST_FAST_WARN_LT(__VA_ARGS__)
+#define FAST_CHECK_LT(...) DOCTEST_FAST_CHECK_LT(__VA_ARGS__)
+#define FAST_REQUIRE_LT(...) DOCTEST_FAST_REQUIRE_LT(__VA_ARGS__)
+#define FAST_WARN_GE(...) DOCTEST_FAST_WARN_GE(__VA_ARGS__)
+#define FAST_CHECK_GE(...) DOCTEST_FAST_CHECK_GE(__VA_ARGS__)
+#define FAST_REQUIRE_GE(...) DOCTEST_FAST_REQUIRE_GE(__VA_ARGS__)
+#define FAST_WARN_LE(...) DOCTEST_FAST_WARN_LE(__VA_ARGS__)
+#define FAST_CHECK_LE(...) DOCTEST_FAST_CHECK_LE(__VA_ARGS__)
+#define FAST_REQUIRE_LE(...) DOCTEST_FAST_REQUIRE_LE(__VA_ARGS__)
+
+#define FAST_WARN_UNARY(...) DOCTEST_FAST_WARN_UNARY(__VA_ARGS__)
+#define FAST_CHECK_UNARY(...) DOCTEST_FAST_CHECK_UNARY(__VA_ARGS__)
+#define FAST_REQUIRE_UNARY(...) DOCTEST_FAST_REQUIRE_UNARY(__VA_ARGS__)
+#define FAST_WARN_UNARY_FALSE(...) DOCTEST_FAST_WARN_UNARY_FALSE(__VA_ARGS__)
+#define FAST_CHECK_UNARY_FALSE(...) DOCTEST_FAST_CHECK_UNARY_FALSE(__VA_ARGS__)
+#define FAST_REQUIRE_UNARY_FALSE(...) DOCTEST_FAST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
+
+#define TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, __VA_ARGS__)
+
+#endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PUBLIC_MACROS
+
+DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
+
+#endif // DOCTEST_LIBRARY_INCLUDED
+
+#if defined(DOCTEST_CONFIG_IMPLEMENT) && !defined(DOCTEST_LIBRARY_IMPLEMENTATION)
+
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-macros")
+#define DOCTEST_LIBRARY_IMPLEMENTATION
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+#ifndef DOCTEST_PARTS_PRIVATE_PRELUDE
+#define DOCTEST_PARTS_PRIVATE_PRELUDE
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+
+// required includes - will go only in one translation unit!
+#include <ctime>
+#include <cmath>
+#include <climits>
+// borland (Embarcadero) compiler requires math.h and not cmath -
+// https://github.com/doctest/doctest/pull/37
+#ifdef __BORLANDC__
+#include <math.h>
+#endif // __BORLANDC__
+#include <new>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <utility>
+#include <fstream>
+#include <sstream>
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+#include <iostream>
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+#include <algorithm>
+#include <iomanip>
+#include <vector>
+#ifndef DOCTEST_CONFIG_NO_MULTITHREADING
+#include <atomic>
+#include <mutex>
+#define DOCTEST_DECLARE_MUTEX(name) std::mutex name;
+#define DOCTEST_DECLARE_STATIC_MUTEX(name) static DOCTEST_DECLARE_MUTEX(name)
+#define DOCTEST_LOCK_MUTEX(name) const std::lock_guard<std::mutex> DOCTEST_ANONYMOUS(DOCTEST_ANON_LOCK_)(name);
+#else // DOCTEST_CONFIG_NO_MULTITHREADING
+#define DOCTEST_DECLARE_MUTEX(name)
+#define DOCTEST_DECLARE_STATIC_MUTEX(name)
+#define DOCTEST_LOCK_MUTEX(name)
+#endif // DOCTEST_CONFIG_NO_MULTITHREADING
+#include <set>
+#include <map>
+#include <unordered_set>
+#include <exception>
+#include <stdexcept>
+#if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
+#include <csignal>
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS
+#include <cfloat>
+#include <cctype>
+#include <cstdint>
+#include <string>
+
+#ifdef DOCTEST_PLATFORM_MAC
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/sysctl.h>
+#endif // DOCTEST_PLATFORM_MAC
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+
+// defines for a leaner windows.h
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#define DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
+#endif // WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#define DOCTEST_UNDEF_NOMINMAX
+#endif // NOMINMAX
+
+// not sure what AfxWin.h is for - here I do what Catch does
+#ifdef __AFXDLL
+#include <AfxWin.h>
+#else
+#include <windows.h>
+#endif
+#include <io.h>
+
+#ifdef DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
+#undef WIN32_LEAN_AND_MEAN
+#undef DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
+#endif // DOCTEST_UNDEF_WIN32_LEAN_AND_MEAN
+#ifdef DOCTEST_UNDEF_NOMINMAX
+#undef NOMINMAX
+#undef DOCTEST_UNDEF_NOMINMAX
+#endif // DOCTEST_UNDEF_NOMINMAX
+
+#else // DOCTEST_PLATFORM_WINDOWS
+
+#include <sys/time.h>
+#include <unistd.h>
+
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+// this is a fix for https://github.com/doctest/doctest/issues/348
+// https://mail.gnome.org/archives/xml/2012-January/msg00000.html
+#if !defined(HAVE_UNISTD_H) && !defined(STDOUT_FILENO)
+#define STDOUT_FILENO fileno(stdout)
+#endif // HAVE_UNISTD_H
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+// counts the number of elements in a C array
+#define DOCTEST_COUNTOF(x) (sizeof(x) / sizeof(x[0]))
+
+#ifdef DOCTEST_CONFIG_DISABLE
+#define DOCTEST_BRANCH_ON_DISABLED(if_disabled, if_not_disabled) if_disabled
+#else // DOCTEST_CONFIG_DISABLE
+#define DOCTEST_BRANCH_ON_DISABLED(if_disabled, if_not_disabled) if_not_disabled
+#endif // DOCTEST_CONFIG_DISABLE
+
+#ifndef DOCTEST_THREAD_LOCAL
+#if defined(DOCTEST_CONFIG_NO_MULTITHREADING) || DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_THREAD_LOCAL
+#else // DOCTEST_MSVC
+#define DOCTEST_THREAD_LOCAL thread_local
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_THREAD_LOCAL
+
+#ifndef DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES
+#define DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES 32
+#endif
+
+#ifndef DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE
+#define DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE 64
+#endif
+
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#define DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+#endif
+
+#ifndef DOCTEST_CDECL
+#define DOCTEST_CDECL __cdecl
+#endif
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_PRELUDE
+#ifndef DOCTEST_PARTS_PRIVATE_CONTEXT_STATE
+#define DOCTEST_PARTS_PRIVATE_CONTEXT_STATE
+
+#ifndef DOCTEST_PARTS_PRIVATE_TIMER
+#define DOCTEST_PARTS_PRIVATE_TIMER
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+namespace timer_large_integer {
+
+#if defined(DOCTEST_PLATFORM_WINDOWS)
+using type = ULONGLONG;
+#else  // DOCTEST_PLATFORM_WINDOWS
+using type = std::uint64_t;
+#endif // DOCTEST_PLATFORM_WINDOWS
+} // namespace timer_large_integer
+
+using ticks_t = timer_large_integer::type;
+
+ticks_t getCurrentTicks();
+
+struct Timer {
+    void start();
+    unsigned int getElapsedMicroseconds() const;
+    double getElapsedSeconds() const;
+
+private:
+    ticks_t m_ticks = 0;
+};
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_TIMER
+#ifndef DOCTEST_PARTS_PRIVATE_ATOMIC
+#define DOCTEST_PARTS_PRIVATE_ATOMIC
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#ifdef DOCTEST_CONFIG_NO_MULTITHREADING
+template <typename T>
+using Atomic = T;
+#else  // DOCTEST_CONFIG_NO_MULTITHREADING
+template <typename T>
+using Atomic = std::atomic<T>;
+#endif // DOCTEST_CONFIG_NO_MULTITHREADING
+
+#if defined(DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS) || defined(DOCTEST_CONFIG_NO_MULTITHREADING)
+template <typename T>
+using MultiLaneAtomic = Atomic<T>;
+#else  // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+// Provides a multilane implementation of an atomic variable that supports add, sub, load,
+// store. Instead of using a single atomic variable, this splits up into multiple ones,
+// each sitting on a separate cache line. The goal is to provide a speedup when most
+// operations are modifying. It achieves this with two properties:
+//
+// * Multiple atomics are used, so chance of congestion from the same atomic is reduced.
+// * Each atomic sits on a separate cache line, so false sharing is reduced.
+//
+// The disadvantage is that there is a small overhead due to the use of TLS, and load/store
+// is slower because all atomics have to be accessed.
+template <typename T>
+class MultiLaneAtomic {
+    struct CacheLineAlignedAtomic {
+        Atomic<T> atomic{};
+        char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
+    };
+    CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
+
+    static_assert(
+        sizeof(CacheLineAlignedAtomic) == DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE,
+        "guarantee one atomic takes exactly one cache line"
+    );
+
+public:
+    T operator++() DOCTEST_NOEXCEPT {
+        return fetch_add(1) + 1;
+    }
+
+    T operator++(int) DOCTEST_NOEXCEPT { // NOLINT(cert-dcl21-cpp)
+        return fetch_add(1);
+    }
+
+    T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        return myAtomic().fetch_add(arg, order);
+    }
+
+    T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        return myAtomic().fetch_sub(arg, order);
+    }
+
+    operator T() const DOCTEST_NOEXCEPT {
+        return load();
+    }
+
+    T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
+        auto result = T();
+        for (const auto &c: m_atomics) {
+            result += c.atomic.load(order);
+        }
+        return result;
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator)
+    T operator=(T desired) DOCTEST_NOEXCEPT {
+        store(desired);
+        return desired;
+    }
+
+    void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        // first value becomes desired", all others become 0.
+        for (auto &c: m_atomics) {
+            c.atomic.store(desired, order);
+            desired = {};
+        }
+    }
+
+private:
+    // Each thread has a different atomic that it operates on. If more than NumLanes threads
+    // use this, some will use the same atomic. So performance will degrade a bit, but still
+    // everything will work.
+    //
+    // The logic here is a bit tricky. The call should be as fast as possible, so that there
+    // is minimal to no overhead in determining the correct atomic for the current thread.
+    //
+    // 1. A global static counter laneCounter counts continuously up.
+    // 2. Each successive thread will use modulo operation of that counter so it gets an atomic
+    //    assigned in a round-robin fashion.
+    // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
+    //    little overhead.
+    Atomic<T> &myAtomic() DOCTEST_NOEXCEPT {
+        static Atomic<size_t> laneCounter;
+        DOCTEST_THREAD_LOCAL size_t tlsLaneIdx = laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
+
+        return m_atomics[tlsLaneIdx].atomic;
+    }
+};
+#endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_ATOMIC
+#ifndef DOCTEST_PARTS_PRIVATE_TRAVERSAL
+#define DOCTEST_PARTS_PRIVATE_TRAVERSAL
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+struct DecisionPoint {
+    // Number of branches available at this depth for the current traversal path.
+    size_t branch_count = 0;
+    // Encountered sibling subcases in source order for subcase decision points.
+    std::vector<SubcaseSignature> subcases;
+};
+
+class TraversalState {
+public:
+    size_t activeSubcaseDepth() const {
+        return m_activeSubcaseDepth;
+    }
+
+    void resetForTestCase();
+    void resetForRun();
+    bool advance();
+    bool tryEnterSubcase(const SubcaseSignature &signature);
+    void leaveSubcase();
+    size_t unwindActiveSubcases();
+    size_t acquireGeneratorIndex(size_t count);
+
+private:
+    // decisionPath is the selected traversal prefix; discoveredDecisionPath is rebuilt
+    // on each rerun to describe the branches encountered at each depth.
+    std::vector<DecisionPoint> m_discoveredDecisionPath;
+    std::vector<size_t> m_decisionPath;
+    size_t m_decisionDepth = 0;
+    std::vector<size_t> m_enteredSubcaseDepths;
+    size_t m_activeSubcaseDepth = 0;
+
+    DecisionPoint &ensureDecisionPointAtCurrentDepth();
+};
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_TRAVERSAL
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+// this holds both parameters from the command line and runtime data for tests
+struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats {
+    MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
+    MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
+
+    std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
+
+    std::vector<IReporter *> reporters_currently_used;
+
+    assert_handler ah = nullptr;
+
+    Timer timer;
+
+    std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
+
+    // Backtrack traversal state shared by SUBCASE and GENERATE.
+    TraversalState traversal;
+    Atomic<bool> shouldLogCurrentException;
+
+    void resetRunData();
+
+    void finalizeTestCaseData();
+};
+
+extern ContextState *g_cs;
+
+// used to avoid locks for the debug output
+// TODO: figure out if this is indeed necessary/correct - seems like either there still
+// could be a race or that there wouldn't be a race even if using the context directly
+extern DOCTEST_THREAD_LOCAL bool g_no_colors;
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_CONTEXT_STATE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+using detail::g_cs;
+
+AssertData::AssertData(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const StringContains &exception_string
+)
+    : m_test_case(g_cs->currentTest),
+      m_at(at),
+      m_file(file),
+      m_line(line),
+      m_expr(expr),
+      m_failed(true),
+      m_threw(false),
+      m_threw_as(false),
+      m_exception_type(exception_type),
+      m_exception_string(exception_string) {
+#if DOCTEST_MSVC
+    if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        ++m_expr;
+#endif // MSVC
+}
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
+    : m_at(at) {}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+#ifndef DOCTEST_PARTS_PRIVATE_REPORTER
+#define DOCTEST_PARTS_PRIVATE_REPORTER
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+// the int (priority) is part of the key for automatic sorting - sadly one can register a
+// reporter with a duplicate name and a different priority but hopefully that won't happen often :|
+using reporterMap = std::map<std::pair<int, String>, detail::reporterCreatorFunc>;
+
+reporterMap &getReporters() noexcept;
+reporterMap &getListeners() noexcept;
+} // namespace detail
+
+#define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...)                                                               \
+    for (auto &curr_rep: g_cs->reporters_currently_used)                                                               \
+    curr_rep->function(__VA_ARGS__)
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_REPORTER
+#ifndef DOCTEST_PARTS_PRIVATE_ASSERT_HANDLER
+#define DOCTEST_PARTS_PRIVATE_ASSERT_HANDLER
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+void addAssert(assertType::Enum at);
+
+void addFailedAssert(assertType::Enum at);
+
+#if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
+void reportFatal(const std::string &message);
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_ASSERT_HANDLER
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+void addAssert(assertType::Enum at) {
+    if ((at & assertType::is_warn) == 0)
+        g_cs->numAssertsCurrentTest_atomic++;
+}
+
+void addFailedAssert(assertType::Enum at) {
+    if ((at & assertType::is_warn) == 0)
+        g_cs->numAssertsFailedCurrentTest_atomic++;
+}
+
+#if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
+void reportFatal(const std::string &message) {
+    g_cs->failure_flags |= TestCaseFailureReason::Crash;
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
+
+    for (size_t i = g_cs->traversal.unwindActiveSubcases(); i > 0; --i)
+        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+    g_cs->finalizeTestCaseData();
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+}
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+void failed_out_of_a_testing_context(const AssertData &ad) {
+    if (g_cs->ah)
+        g_cs->ah(ad);
+    else
+        std::abort();
+}
+
+bool decomp_assert(assertType::Enum at, const char *file, int line, const char *expr, const Result &result) {
+    const bool failed = !result.m_passed;
+
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
+    DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
+    return !failed;
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+MessageBuilder::MessageBuilder(const char *file, int line, assertType::Enum severity) {
+    m_stream = tlssPush();
+    m_file = file;
+    m_line = line;
+    m_severity = severity;
+}
+
+MessageBuilder::~MessageBuilder() noexcept(false) {
+    if (!logged)
+        tlssPop();
+}
+
+bool MessageBuilder::log() {
+    if (!logged) {
+        m_string = tlssPop();
+        logged = true;
+    }
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
+
+    const bool isWarn = m_severity & assertType::is_warn;
+
+    // warn is just a message in this context so we don't treat it as an assert
+    if (!isWarn) {
+        addAssert(m_severity);
+        addFailedAssert(m_severity);
+    }
+
+    return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
+           (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
+
+void MessageBuilder::react() {
+    if (m_severity & assertType::is_require)
+        throwException();
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+#ifndef DOCTEST_PARTS_PRIVATE_EXCEPTION_TRANSLATOR
+#define DOCTEST_PARTS_PRIVATE_EXCEPTION_TRANSLATOR
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+std::vector<const IExceptionTranslator *> &getExceptionTranslators() noexcept;
+String translateActiveException() noexcept;
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_EXCEPTION_TRANSLATOR
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+Result::Result(bool passed, const String &decomposition)
+    : m_passed(passed), m_decomp(decomposition) {}
+
+ResultBuilder::ResultBuilder(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const String &exception_string
+)
+    : AssertData(at, file, line, expr, exception_type, exception_string) {
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+ResultBuilder::ResultBuilder(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const Contains &exception_string
+)
+    : AssertData(at, file, line, expr, exception_type, exception_string) {}
+
+void ResultBuilder::setResult(const Result &res) {
+    m_decomp = res.m_decomp;
+    m_failed = !res.m_passed;
+}
+
+void ResultBuilder::translateException() {
+    m_threw = true;
+    m_exception = translateActiveException();
+}
+
+bool ResultBuilder::log() {
+    if (m_at & assertType::is_throws) {
+        m_failed = !m_threw;
+    } else if ((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) {
+        m_failed = !m_threw_as || !m_exception_string.check(m_exception);
+    } else if (m_at & assertType::is_throws_as) {
+        m_failed = !m_threw_as;
+    } else if (m_at & assertType::is_throws_with) {
+        m_failed = !m_exception_string.check(m_exception);
+    } else if (m_at & assertType::is_nothrow) {
+        m_failed = m_threw;
+    }
+
+    if (m_exception.size())
+        m_exception = "\"" + m_exception + "\"";
+
+    if (is_running_in_test) {
+        addAssert(m_at);
+        DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
+
+        if (m_failed)
+            addFailedAssert(m_at);
+    } else if (m_failed) {
+        failed_out_of_a_testing_context(*this);
+    }
+
+    return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
+           (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
+
+void ResultBuilder::react() const {
+    if (m_failed && checkIfShouldThrow(m_at))
+        throwException();
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+#ifndef DOCTEST_PARTS_PRIVATE_EXCEPTIONS
+#define DOCTEST_PARTS_PRIVATE_EXCEPTIONS
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+
+template <typename Ex>
+DOCTEST_NORETURN void throw_exception(const Ex &e) {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+    throw e;
+#else // DOCTEST_CONFIG_NO_EXCEPTIONS
+#ifdef DOCTEST_CONFIG_HANDLE_EXCEPTION
+    DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
+#else // DOCTEST_CONFIG_HANDLE_EXCEPTION
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+    std::cerr << "doctest will terminate because it needed to throw an exception.\n"
+              << "The message was: " << e.what() << '\n';
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+#endif // DOCTEST_CONFIG_HANDLE_EXCEPTION
+    std::terminate();
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+}
+
+#ifndef DOCTEST_INTERNAL_ERROR
+#define DOCTEST_INTERNAL_ERROR(msg)                                                                                    \
+    detail::throw_exception(std::logic_error(__FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
+#endif // DOCTEST_INTERNAL_ERROR
+} // namespace detail
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_EXCEPTIONS
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+const char *assertString(assertType::Enum at) {
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4061) // enum 'x' in switch of enum 'y' is not explicitly handled
+#define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type)                                                                 \
+    case assertType::DT_##assert_type: return #assert_type
+#define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type)                                                                \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_##assert_type);                                                             \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK_##assert_type);                                                            \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE_##assert_type)
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")
+    switch (at) {
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(FALSE);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_AS);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_WITH);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_WITH_AS);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(NOTHROW);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(EQ);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(NE);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(GT);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(LT);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(GE);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(LE);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(UNARY);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(UNARY_FALSE);
+
+        default: DOCTEST_INTERNAL_ERROR("Tried stringifying invalid assert type!");
+    }
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+}
+
+const char *failureString(assertType::Enum at) {
+    if (at & assertType::is_warn)
+        return "WARNING";
+    if (at & assertType::is_check)
+        return "ERROR";
+    if (at & assertType::is_require)
+        return "FATAL ERROR";
+    return "";
+}
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#if !defined(DOCTEST_CONFIG_COLORS_NONE)
+#if !defined(DOCTEST_CONFIG_COLORS_WINDOWS) && !defined(DOCTEST_CONFIG_COLORS_ANSI)
+#ifdef DOCTEST_PLATFORM_WINDOWS
+#define DOCTEST_CONFIG_COLORS_WINDOWS
+#else // linux
+#define DOCTEST_CONFIG_COLORS_ANSI
+#endif // platform
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
+#endif // DOCTEST_CONFIG_COLORS_NONE
+
+namespace doctest {
+
+namespace detail {
+void color_to_stream(std::ostream &, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
+} // namespace detail
+
+namespace Color {
+std::ostream &operator<<(std::ostream &s, Color::Enum code) {
+    detail::color_to_stream(s, code);
+    return s;
+}
+} // namespace Color
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+void color_to_stream(std::ostream &s, Color::Enum code) {
+    static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
+    static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
+#ifdef DOCTEST_CONFIG_COLORS_ANSI
+    if (g_no_colors || (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
+        return;
+
+    auto col = ""; // NOLINT(clang-analyzer-deadcode.DeadStores)
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")
+    switch (code) {
+        case Color::Red:         col = "[0;31m"; break;
+        case Color::Green:       col = "[0;32m"; break;
+        case Color::Blue:        col = "[0;34m"; break;
+        case Color::Cyan:        col = "[0;36m"; break;
+        case Color::Yellow:      col = "[0;33m"; break;
+        case Color::Grey:        col = "[1;30m"; break;
+        case Color::LightGrey:   col = "[0;37m"; break;
+        case Color::BrightRed:   col = "[1;31m"; break;
+        case Color::BrightGreen: col = "[1;32m"; break;
+        case Color::BrightWhite: col = "[1;37m"; break;
+        case Color::Bright:      // invalid
+        case Color::None:
+        case Color::White:
+        default:                 col = "[0m";
+    }
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    s << "\033" << col;
+#endif // DOCTEST_CONFIG_COLORS_ANSI
+
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+    if (g_no_colors || (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
+        return;
+
+    static struct ConsoleHelper {
+        HANDLE stdoutHandle;
+        WORD origFgAttrs;
+        WORD origBgAttrs;
+
+        ConsoleHelper() {
+            stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+            GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
+            origFgAttrs =
+                csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+            origBgAttrs =
+                csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+        }
+    } ch;
+
+#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
+
+    // clang-format off
+    switch (code) {
+        case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
+        case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
+        case Color::Green:       DOCTEST_SET_ATTR(FOREGROUND_GREEN);                                    break;
+        case Color::Blue:        DOCTEST_SET_ATTR(FOREGROUND_BLUE);                                     break;
+        case Color::Cyan:        DOCTEST_SET_ATTR(FOREGROUND_BLUE | FOREGROUND_GREEN);                  break;
+        case Color::Yellow:      DOCTEST_SET_ATTR(FOREGROUND_RED | FOREGROUND_GREEN);                   break;
+        case Color::Grey:        DOCTEST_SET_ATTR(0);                                                   break;
+        case Color::LightGrey:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY);                                break;
+        case Color::BrightRed:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_RED);               break;
+        case Color::BrightGreen: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN);             break;
+        case Color::BrightWhite: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
+        case Color::None:
+        case Color::Bright:      // invalid
+        default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
+    }
+        // clang-format on
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLED
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+const ContextOptions *getContextOptions() {
+    return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs);
+}
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+#ifndef DOCTEST_PARTS_PRIVATE_REPORTERS_COMMON
+#define DOCTEST_PARTS_PRIVATE_REPORTERS_COMMON
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_OPTIONS_PREFIX
+#define DOCTEST_CONFIG_OPTIONS_PREFIX "dt-"
+#endif
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+void fulltext_log_assert_to_stream(std::ostream &s, const AssertData &rb);
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_REPORTERS_COMMON
+#ifndef DOCTEST_PARTS_PRIVATE_REPORTERS_DEBUG_OUTPUT_WINDOW
+#define DOCTEST_PARTS_PRIVATE_REPORTERS_DEBUG_OUTPUT_WINDOW
+
+#ifndef DOCTEST_PARTS_PRIVATE_REPORTERS_CONSOLE
+#define DOCTEST_PARTS_PRIVATE_REPORTERS_CONSOLE
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifdef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+#define DOCTEST_OPTIONS_PREFIX_DISPLAY DOCTEST_CONFIG_OPTIONS_PREFIX
+#else
+#define DOCTEST_OPTIONS_PREFIX_DISPLAY ""
+#endif
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+struct Whitespace {
+    int nrSpaces;
+    explicit Whitespace(int nr);
+};
+
+std::ostream &operator<<(std::ostream &out, const Whitespace &ws);
+
+struct ConsoleReporter : public IReporter {
+    std::ostream &s;
+    bool hasLoggedCurrentTestStart;
+    std::vector<SubcaseSignature> subcasesStack;
+    size_t currentSubcaseLevel;
+    DOCTEST_DECLARE_MUTEX(mutex)
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions &opt;
+    const TestCaseData *tc;
+
+    ConsoleReporter(const ContextOptions &co);
+
+    ConsoleReporter(const ContextOptions &co, std::ostream &ostr);
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
+    // =========================================================================================
+
+    void separator_to_stream();
+
+    static const char *getSuccessOrFailString(bool success, assertType::Enum at, const char *success_str);
+
+    static Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at);
+
+    void successOrFailColoredStringToStream(bool success, assertType::Enum at, const char *success_str = "SUCCESS");
+
+    void log_contexts();
+
+    // this was requested to be made virtual so users could override it
+    virtual void file_line_to_stream(const char *file, int line, const char *tail = "");
+
+    void logTestStart();
+
+    void printVersion();
+
+    void printIntro();
+
+    void printHelp();
+
+    void printRegisteredReporters();
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData &in) override;
+
+    void test_run_start() override;
+
+    void test_run_end(const TestRunStats &p) override;
+
+    void test_case_start(const TestCaseData &in) override;
+
+    void test_case_reenter(const TestCaseData &) override;
+
+    void test_case_end(const CurrentTestCaseStats &st) override;
+
+    void test_case_exception(const TestCaseException &e) override;
+
+    void subcase_start(const SubcaseSignature &subc) override;
+
+    void subcase_end() override;
+
+    void log_assert(const AssertData &rb) override;
+
+    void log_message(const MessageData &mb) override;
+
+    void test_case_skipped(const TestCaseData &) override;
+};
+
+DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_REPORTERS_CONSOLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+struct DebugOutputWindowReporter : public ConsoleReporter {
+    DOCTEST_THREAD_LOCAL static std::ostringstream oss;
+
+    DebugOutputWindowReporter(const ContextOptions &co);
+
+    void test_run_start() override;
+    void test_run_end(const TestRunStats &in) override;
+    void test_case_start(const TestCaseData &in) override;
+    void test_case_reenter(const TestCaseData &in) override;
+    void test_case_end(const CurrentTestCaseStats &in) override;
+    void test_case_exception(const TestCaseException &in) override;
+    void subcase_start(const SubcaseSignature &in) override;
+    void subcase_end(DOCTEST_EMPTY DOCTEST_EMPTY) override;
+    void log_assert(const AssertData &in) override;
+    void log_message(const MessageData &in) override;
+    void test_case_skipped(const TestCaseData &in) override;
+};
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_REPORTERS_DEBUG_OUTPUT_WINDOW
+#ifndef DOCTEST_PARTS_PRIVATE_TEST_CASE
+#define DOCTEST_PARTS_PRIVATE_TEST_CASE
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+// all the registered tests
+std::set<TestCase> &getRegisteredTests();
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_TEST_CASE
+#ifndef DOCTEST_PARTS_PRIVATE_FILTERS
+#define DOCTEST_PARTS_PRIVATE_FILTERS
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+// matching of a string against a wildcard mask (case sensitivity configurable) taken from
+// https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
+int wildcmp(const char *str, const char *wild, bool caseSensitive);
+
+// checks if the name matches any of the filters (and can be configured what to do when empty)
+bool matchesAny(const char *name, const std::vector<String> &filters, bool matchEmpty, bool caseSensitive);
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_FILTERS
+#ifndef DOCTEST_PARTS_PRIVATE_SIGNALS
+#define DOCTEST_PARTS_PRIVATE_SIGNALS
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
+struct FatalConditionHandler {
+    static void reset();
+    static void allocateAltStackMem();
+    static void freeAltStackMem();
+};
+#else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+
+struct SignalDefs {
+    DWORD id;
+    const char *name;
+};
+
+struct FatalConditionHandler {
+    static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo);
+    static void allocateAltStackMem();
+    static void freeAltStackMem();
+
+    FatalConditionHandler();
+
+    static void reset();
+
+    ~FatalConditionHandler();
+
+private:
+    static UINT prev_error_mode_1;
+    static int prev_error_mode_2;
+    static unsigned int prev_abort_behavior;
+    static int prev_report_mode;
+    static _HFILE prev_report_file;
+    static void(DOCTEST_CDECL *prev_sigabrt_handler)(int);
+    static std::terminate_handler original_terminate_handler;
+    static bool isSet;
+    static ULONG guaranteeSize;
+    static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
+};
+
+#else // DOCTEST_PLATFORM_WINDOWS
+
+struct SignalDefs {
+    int id;
+    const char *name;
+};
+
+struct FatalConditionHandler {
+    static bool isSet;
+    static struct sigaction oldSigActions[6];
+    static stack_t oldSigStack;
+    static size_t altStackSize;
+    static char *altStackMem;
+
+    static void handleSignal(int sig);
+
+    static void allocateAltStackMem();
+
+    static void freeAltStackMem();
+
+    FatalConditionHandler();
+
+    ~FatalConditionHandler();
+    static void reset();
+};
+
+#endif // DOCTEST_PLATFORM_WINDOWS
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_SIGNALS
+
+// Fix for #1035
+#ifndef DOCTEST_PARTS_PRIVATE_REPORTERS_JUNIT
+#define DOCTEST_PARTS_PRIVATE_REPORTERS_JUNIT
+
+#ifndef DOCTEST_PARTS_PRIVATE_XML
+#define DOCTEST_PARTS_PRIVATE_XML
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+// =================================================================================================
+// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h
+// This is done so cherry-picking bug fixes is trivial - even the style/formatting is untouched.
+// =================================================================================================
+/* clang-format off */ /* NOLINTBEGIN */
+
+    class XmlEncode {
+    public:
+        enum ForWhat { ForTextNodes, ForAttributes };
+
+        XmlEncode( std::string const& str, ForWhat forWhat = ForTextNodes );
+
+        void encodeTo( std::ostream& os ) const;
+
+        friend std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode );
+
+    private:
+        std::string m_str;
+        ForWhat m_forWhat;
+    };
+
+    class XmlWriter {
+    public:
+
+        class ScopedElement {
+        public:
+            ScopedElement( XmlWriter* writer );
+
+            ScopedElement( ScopedElement&& other ) DOCTEST_NOEXCEPT;
+            ScopedElement& operator=( ScopedElement&& other ) DOCTEST_NOEXCEPT;
+
+            ~ScopedElement();
+
+            ScopedElement& writeText( std::string const& text, bool indent = true );
+
+            template<typename T>
+            ScopedElement& writeAttribute( std::string const& name, T const& attribute ) {
+                m_writer->writeAttribute( name, attribute );
+                return *this;
+            }
+
+        private:
+            mutable XmlWriter* m_writer = nullptr;
+        };
+
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+        XmlWriter( std::ostream& os = std::cout );
+#else // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+        XmlWriter( std::ostream& os );
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+        ~XmlWriter();
+
+        XmlWriter( XmlWriter const& ) = delete;
+        XmlWriter& operator=( XmlWriter const& ) = delete;
+
+        XmlWriter& startElement( std::string const& name );
+
+        ScopedElement scopedElement( std::string const& name );
+
+        XmlWriter& endElement();
+
+        XmlWriter& writeAttribute( std::string const& name, std::string const& attribute );
+
+        XmlWriter& writeAttribute( std::string const& name, const char* attribute );
+
+        XmlWriter& writeAttribute( std::string const& name, bool attribute );
+
+        template<typename T>
+        XmlWriter& writeAttribute( std::string const& name, T const& attribute ) {
+        std::stringstream rss;
+            rss << attribute;
+            return writeAttribute( name, rss.str() );
+        }
+
+        XmlWriter& writeText( std::string const& text, bool indent = true );
+
+        //XmlWriter& writeComment( std::string const& text );
+
+        //void writeStylesheetRef( std::string const& url );
+
+        //XmlWriter& writeBlankLine();
+
+        void ensureTagClosed();
+
+        void writeDeclaration();
+
+    private:
+
+        void newlineIfNecessary();
+
+        bool m_tagIsOpen = false;
+        bool m_needsNewline = false;
+        std::vector<std::string> m_tags;
+        std::string m_indent;
+        std::ostream& m_os;
+    };
+
+/* clang-format on */ /* NOLINTEND */
+// =================================================================================================
+// End of copy-pasted code from Catch
+// =================================================================================================
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_XML
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+// TODO:
+// - log_message()
+// - respond to queries
+// - honor remaining options
+// - more attributes in tags
+struct JUnitReporter : public IReporter {
+    detail::XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
+    detail::Timer timer;
+    std::vector<String> deepestSubcaseStackNames;
+
+    struct JUnitTestCaseData {
+        static std::string getCurrentTimestamp();
+
+        struct JUnitTestMessage {
+            JUnitTestMessage(const std::string &_message, const std::string &_type, const std::string &_details);
+
+            JUnitTestMessage(const std::string &_message, const std::string &_details);
+
+            std::string message, type, details;
+        };
+
+        struct JUnitTestCase {
+            JUnitTestCase(const std::string &_classname, const std::string &_name);
+
+            std::string classname, name;
+            double time;
+            std::vector<JUnitTestMessage> failures, errors;
+        };
+
+        void add(const std::string &classname, const std::string &name);
+
+        void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack);
+
+        void addTime(double time);
+
+        void addFailure(const std::string &message, const std::string &type, const std::string &details);
+
+        void addError(const std::string &message, const std::string &details);
+
+        std::vector<JUnitTestCase> testcases;
+        double totalSeconds = 0;
+        int totalErrors = 0, totalFailures = 0;
+    };
+
+    JUnitTestCaseData testCaseData;
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions &opt;
+    const TestCaseData *tc = nullptr;
+
+    JUnitReporter(const ContextOptions &co);
+
+    unsigned line(unsigned l) const;
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData &) override;
+
+    void test_run_start() override;
+
+    void test_run_end(const TestRunStats &p) override;
+
+    void test_case_start(const TestCaseData &in) override;
+
+    void test_case_reenter(const TestCaseData &in) override;
+
+    void test_case_end(const CurrentTestCaseStats &) override;
+
+    void test_case_exception(const TestCaseException &e) override;
+
+    void subcase_start(const SubcaseSignature &in) override;
+
+    void subcase_end() override;
+
+    void log_assert(const AssertData &rb) override;
+
+    void log_message(const MessageData &mb) override;
+
+    void test_case_skipped(const TestCaseData &) override;
+
+    static void log_contexts(std::ostringstream &s);
+};
+
+DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_REPORTERS_JUNIT
+#ifndef DOCTEST_PARTS_PRIVATE_REPORTERS_XML
+#define DOCTEST_PARTS_PRIVATE_REPORTERS_XML
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+struct XmlReporter : public IReporter {
+    detail::XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions &opt;
+    const TestCaseData *tc = nullptr;
+
+    XmlReporter(const ContextOptions &co);
+
+    void log_contexts();
+
+    unsigned line(unsigned l) const;
+
+    void test_case_start_impl(const TestCaseData &in);
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData &in) override;
+
+    void test_run_start() override;
+
+    void test_run_end(const TestRunStats &p) override;
+
+    void test_case_start(const TestCaseData &in) override;
+
+    void test_case_reenter(const TestCaseData &) override;
+
+    void test_case_end(const CurrentTestCaseStats &st) override;
+
+    void test_case_exception(const TestCaseException &e) override;
+
+    void subcase_start(const SubcaseSignature &in) override;
+
+    void subcase_end() override;
+
+    void log_assert(const AssertData &rb) override;
+
+    void log_message(const MessageData &mb) override;
+
+    void test_case_skipped(const TestCaseData &in) override;
+};
+
+DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_REPORTERS_XML
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+bool is_running_in_test = false;
+
+#ifdef DOCTEST_CONFIG_DISABLE
+
+// NOLINTBEGIN(readability-convert-member-functions-to-static)
+Context::Context(int, const char *const *) {}
+Context::~Context() = default;
+void Context::applyCommandLine(int, const char *const *) {}
+void Context::addFilter(const char *, const char *) {}
+void Context::clearFilters() {}
+void Context::setOption(const char *, bool) {}
+void Context::setOption(const char *, int) {}
+void Context::setOption(const char *, const char *) {}
+bool Context::shouldExit() {
+    return false;
+}
+void Context::setAsDefaultForAssertsOutOfTestCases() {}
+void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream *) {}
+int Context::run() {
+    return 0;
+}
+// NOLINTEND(readability-convert-member-functions-to-static)
+
+#else
+
+namespace detail {
+// for sorting tests by file/line
+bool fileOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    // this is needed because MSVC gives different case for drive letters
+    // for __FILE__ when evaluated in a header and a source file
+    const int res = lhs->m_file.compare(rhs->m_file, static_cast<bool>(DOCTEST_MSVC));
+    if (res != 0)
+        return res < 0;
+    if (lhs->m_line != rhs->m_line)
+        return lhs->m_line < rhs->m_line;
+    return lhs->m_template_id < rhs->m_template_id;
+}
+
+// for sorting tests by suite/file/line
+bool suiteOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
+    if (res != 0)
+        return res < 0;
+    return fileOrderComparator(lhs, rhs);
+}
+
+// for sorting tests by name/suite/file/line
+bool nameOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    const int res = std::strcmp(lhs->m_name, rhs->m_name);
+    if (res != 0)
+        return res < 0;
+    return suiteOrderComparator(lhs, rhs);
+}
+
+// the implementation of parseOption()
+bool parseOptionImpl(int argc, const char *const *argv, const char *pattern, String *value) {
+    // going from the end to the beginning and stopping on the first occurrence from the end
+    for (int i = argc; i > 0; --i) {
+        auto index = i - 1;
+        auto temp = std::strstr(argv[index], pattern);
+        if (temp && (value || strlen(temp) == strlen(pattern))) {
+            // eliminate matches in which the chars before the option are not '-'
+            bool noBadCharsFound = true;
+            auto curr = argv[index];
+            while (curr != temp) {
+                if (*curr++ != '-') {
+                    noBadCharsFound = false;
+                    break;
+                }
+            }
+            if (noBadCharsFound && argv[index][0] == '-') {
+                if (value) {
+                    // parsing the value of an option
+                    temp += strlen(pattern);
+                    const unsigned len = strlen(temp);
+                    if (len) {
+                        *value = temp;
+                        return true;
+                    }
+                } else {
+                    // just a flag - no value
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+// parses an option and returns the string after the '=' character
+bool parseOption(
+    int argc, const char *const *argv, const char *pattern, String *value = nullptr, const String &defaultVal = String()
+) {
+    if (value)
+        *value = defaultVal;
+#ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+    // offset (normally 3 for "dt-") to skip prefix
+    if (parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), value))
+        return true;
+#endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+    return parseOptionImpl(argc, argv, pattern, value);
+}
+
+// locates a flag on the command line
+bool parseFlag(int argc, const char *const *argv, const char *pattern) {
+    return parseOption(argc, argv, pattern);
+}
+
+// parses a comma separated list of words after a pattern in one of the arguments in argv
+bool parseCommaSepArgs(int argc, const char *const *argv, const char *pattern, std::vector<String> &res) {
+    String filtersString;
+    if (parseOption(argc, argv, pattern, &filtersString)) {
+        // tokenize with "," as a separator, unless escaped with backslash
+        std::ostringstream s;
+        auto flush = [&s, &res]() {
+            auto string = s.str();
+            if (!string.empty()) {
+                res.emplace_back(string.c_str());
+            }
+            s.str("");
+        };
+
+        bool seenBackslash = false;
+        const char *current = filtersString.c_str();
+        const char *end = current + strlen(current);
+        while (current != end) {
+            const char character = *current++;
+            if (seenBackslash) {
+                seenBackslash = false;
+                if (character == ',' || character == '\\') {
+                    s.put(character);
+                    continue;
+                }
+                s.put('\\');
+            }
+            if (character == '\\') {
+                seenBackslash = true;
+            } else if (character == ',') {
+                flush();
+            } else {
+                s.put(character);
+            }
+        }
+
+        if (seenBackslash) {
+            s.put('\\');
+        }
+        flush();
+        return true;
+    }
+    return false;
+}
+
+enum optionType { option_bool, option_int };
+
+// parses an int/bool option from the command line
+bool parseIntOption(int argc, const char *const *argv, const char *pattern, optionType type, int &res) {
+    String parsedValue;
+    if (!parseOption(argc, argv, pattern, &parsedValue))
+        return false;
+
+    if (type) {
+        // integer
+        // TODO: change this to use std::stoi or something else! currently it uses undefined
+        // behavior - assumes '0' on failed parse...
+        // NOLINTNEXTLINE(bugprone-unchecked-string-to-number-conversion, cert-err34-c)
+        const int theInt = std::atoi(parsedValue.c_str());
+        if (theInt != 0) {
+            res = theInt;
+            return true;
+        }
+    } else {
+        // boolean
+        const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
+        const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
+
+        // if the value matches any of the positive/negative possibilities
+        for (unsigned i = 0; i < 4; i++) {
+            if (parsedValue.compare(positive[i], true) == 0) {
+                res = 1;
+                return true;
+            }
+            if (parsedValue.compare(negative[i], true) == 0) {
+                res = 0;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace detail
+
+Context::Context(int argc, const char *const *argv)
+    : p(new detail::ContextState) {
+    parseArgs(argc, argv, true);
+    if (argc)
+        p->binary_name = argv[0];
+}
+
+Context::~Context() {
+    if (detail::g_cs == p)
+        detail::g_cs = nullptr;
+    delete p;
+}
+
+void Context::applyCommandLine(int argc, const char *const *argv) {
+    parseArgs(argc, argv);
+    if (argc)
+        p->binary_name = argv[0];
+}
+
+// parses args
+void Context::parseArgs(int argc, const char *const *argv, bool withDefaults) {
+    using namespace detail;
+
+    // clang-format off
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sfe=",                p->filters[1]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite=",         p->filters[2]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ts=",                 p->filters[2]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite-exclude=", p->filters[3]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tse=",                p->filters[3]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case=",          p->filters[4]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tc=",                 p->filters[4]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case-exclude=",  p->filters[5]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tce=",                p->filters[5]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase=",            p->filters[6]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sc=",                 p->filters[6]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase-exclude=",    p->filters[7]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
+    // clang-format on
+
+    int intRes = 0;
+    String strRes;
+
+#define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                                       \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||                     \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))                      \
+        p->var = static_cast<bool>(intRes);                                                                            \
+    else if (                                                                                                          \
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                                                   \
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname)                                                     \
+    )                                                                                                                  \
+        p->var = true;                                                                                                 \
+    else if (withDefaults)                                                                                             \
+    p->var = default
+
+#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                                            \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||                      \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))                       \
+        p->var = intRes;                                                                                               \
+    else if (withDefaults)                                                                                             \
+    p->var = default
+
+#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                                            \
+    if (parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||                           \
+        parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) || withDefaults)            \
+    p->var = strRes
+
+    DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
+    DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
+    DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
+
+    DOCTEST_PARSE_INT_OPTION("first", "f", first, 0);
+    DOCTEST_PARSE_INT_OPTION("last", "l", last, UINT_MAX);
+
+    DOCTEST_PARSE_INT_OPTION("abort-after", "aa", abort_after, 0);
+    DOCTEST_PARSE_INT_OPTION("subcase-filter-levels", "scfl", subcase_filter_levels, INT_MAX);
+
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("success", "s", success, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-intro", "ni", no_intro, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-version", "nv", no_version, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-colors", "nc", no_colors, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("force-colors", "fc", force_colors, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-breaks", "nb", no_breaks, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skip", "ns", no_skip, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
+    DOCTEST_PARSE_STR_OPTION("strip-file-prefixes", "sfp", strip_file_prefixes, "");
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
+
+    if (withDefaults) {
+        p->help = false;
+        p->version = false;
+        p->count = false;
+        p->list_test_cases = false;
+        p->list_test_suites = false;
+        p->list_reporters = false;
+    }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
+        p->help = true;
+        p->exit = true;
+    }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
+        p->version = true;
+        p->exit = true;
+    }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
+        p->count = true;
+        p->exit = true;
+    }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
+        p->list_test_cases = true;
+        p->exit = true;
+    }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
+        p->list_test_suites = true;
+        p->exit = true;
+    }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
+        p->list_reporters = true;
+        p->exit = true;
+    }
+}
+
+// allows the user to add procedurally to the filters from the command line
+void Context::addFilter(const char *filter, const char *value) {
+    setOption(filter, value);
+}
+
+// allows the user to clear all filters from the command line
+void Context::clearFilters() {
+    for (auto &curr: p->filters)
+        curr.clear();
+}
+
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char *option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
+
+// allows the user to override procedurally the int options from the command line
+void Context::setOption(const char *option, int value) {
+    setOption(option, toString(value).c_str());
+}
+
+// allows the user to override procedurally the string options from the command line
+void Context::setOption(const char *option, const char *value) {
+    auto argv = String("-") + option + "=" + value;
+    auto lvalue = argv.c_str();
+    parseArgs(1, &lvalue);
+}
+
+// users should query this in their main() and exit the program if true
+bool Context::shouldExit() {
+    return p->exit;
+}
+
+void Context::setAsDefaultForAssertsOutOfTestCases() {
+    detail::g_cs = p;
+}
+
+void Context::setAssertHandler(detail::assert_handler ah) {
+    p->ah = ah;
+}
+
+void Context::setCout(std::ostream *out) {
+    p->cout = out;
+}
+
+static class DiscardOStream : public std::ostream {
+private:
+    class : public std::streambuf {
+    private:
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
+
+    protected:
+        std::streamsize xsputn(const char_type *, std::streamsize count) override {
+            return count;
+        }
+
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
+        }
+    } discardBuf;
+
+public:
+    DiscardOStream() noexcept
+        : std::ostream(&discardBuf) {}
+} discardOut;
+
+// the main function that does all the filtering and test running
+int Context::run() {
+    using namespace detail;
+
+    // save the old context state in case such was setup - for using asserts out of a testing context
+    auto old_cs = g_cs;
+    // this is the current contest
+    g_cs = p;
+    is_running_in_test = true;
+
+    g_no_colors = p->no_colors;
+    p->resetRunData();
+
+    std::fstream fstr;
+    if (p->cout == nullptr) {
+        if (p->quiet) {
+            p->cout = &discardOut;
+        } else if (p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
+            if (!fstr.is_open()) {
+                // clang-format off
+                std::cerr << Color::Cyan << "[doctest] " << Color::None << "Could not open " << p->out << " for writing!" << std::endl;
+                std::cerr << Color::Cyan << "[doctest] " << Color::None << "Defaulting to std::cout instead" << std::endl;
+                p->cout = &std::cout;
+                // clang-format on
+            }
+
+        } else {
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            // stdout by default
+            p->cout = &std::cout;
+#else  // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            return EXIT_FAILURE;
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+        }
+    }
+
+    FatalConditionHandler::allocateAltStackMem();
+
+    auto cleanup_and_return = [&]() {
+        FatalConditionHandler::freeAltStackMem();
+
+        if (fstr.is_open())
+            fstr.close();
+
+        // restore context
+        g_cs = old_cs;
+        is_running_in_test = false;
+
+        // we have to free the reporters which were allocated when the run started
+        for (auto &curr: p->reporters_currently_used)
+            delete curr;
+        p->reporters_currently_used.clear();
+
+        if (p->numTestCasesFailed && !p->no_exitcode)
+            return EXIT_FAILURE;
+        return EXIT_SUCCESS;
+    };
+
+    // setup default reporter if none is given through the command line
+    if (p->filters[8].empty())
+        p->filters[8].emplace_back("console");
+
+    // check to see if any of the registered reporters has been selected
+    for (auto &curr: getReporters()) {
+        if (matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
+            p->reporters_currently_used.push_back(curr.second(*g_cs));
+    }
+
+    // TODO: check if there is nothing in reporters_currently_used
+
+    // prepend all listeners
+    for (auto &curr: getListeners())
+        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if (isDebuggerActive() && p->no_debug_output == false)
+        p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    // handle version, help and no_run
+    if (p->no_run || p->version || p->help || p->list_reporters) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
+
+        return cleanup_and_return();
+    }
+
+    std::vector<const TestCase *> testArray;
+    for (auto &curr: getRegisteredTests())
+        testArray.push_back(&curr);
+    p->numTestCases = testArray.size();
+
+    // sort the collected records
+    if (!testArray.empty()) {
+        if (p->order_by.compare("file", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
+        } else if (p->order_by.compare("suite", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
+        } else if (p->order_by.compare("name", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
+        } else if (p->order_by.compare("rand", true) == 0) {
+            std::srand(p->rand_seed);
+
+            // random_shuffle implementation
+            const auto first = testArray.data();
+            for (size_t i = testArray.size() - 1; i > 0; --i) {
+                // NOLINTNEXTLINE(cert-msc30-c, cert-msc50-cpp, concurrency-mt-unsafe, misc-predictable-rand)
+                const int idxToSwap = static_cast<int>(std::rand() % (i + 1));
+
+                const auto temp = first[i];
+
+                first[i] = first[idxToSwap];
+                first[idxToSwap] = temp;
+            }
+        } else if (p->order_by.compare("none", true) == 0) {
+            // means no sorting - beneficial for death tests which call into the executable
+            // with a specific test case in mind - we don't want to slow down the startup times
+        }
+    }
+
+    std::set<String> testSuitesPassingFilt;
+
+    const bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    std::vector<const TestCaseData *> queryResults;
+
+    if (!query_mode)
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
+
+    // invoke the registered functions if they match the filter criteria (or just count them)
+    for (auto &curr: testArray) {
+        const auto &tc = *curr;
+
+        bool skip_me = false;
+        if (tc.m_skip && !p->no_skip)
+            skip_me = true;
+
+        if (!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
+            skip_me = true;
+        if (!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
+            skip_me = true;
+        if (!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
+            skip_me = true;
+
+        if (!skip_me)
+            p->numTestCasesPassingFilters++;
+
+        // skip the test if it is not in the execution range
+        if ((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
+            (p->first > p->numTestCasesPassingFilters))
+            skip_me = true;
+
+        if (skip_me) {
+            if (!query_mode)
+                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
+            continue;
+        }
+
+        // do not execute the test if we are to only count the number of filter passing tests
+        if (p->count)
+            continue;
+
+        // print the name of the test and don't execute it
+        if (p->list_test_cases) {
+            queryResults.push_back(&tc);
+            continue;
+        }
+
+        // print the name of the test suite if not done already and don't execute it
+        if (p->list_test_suites) {
+            if ((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
+                queryResults.push_back(&tc);
+                testSuitesPassingFilt.insert(tc.m_test_suite);
+                p->numTestSuitesPassingFilters++;
+            }
+            continue;
+        }
+
+        // execute the test if it passes all the filtering
+        {
+            p->currentTest = &tc;
+
+            p->failure_flags = TestCaseFailureReason::None;
+            p->seconds = 0;
+
+            // reset atomic counters
+            p->numAssertsFailedCurrentTest_atomic = 0;
+            p->numAssertsCurrentTest_atomic = 0;
+
+            p->traversal.resetForTestCase();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
+
+            p->timer.start();
+
+            bool run_test = true;
+
+            do { // NOLINT(cppcoreguidelines-avoid-do-while)
+                // Reset per-run traversal data while keeping the current decision path prefix.
+                p->traversal.resetForRun();
+
+                p->shouldLogCurrentException = true;
+
+                // reset stuff for logging with INFO()
+                p->stringifiedContexts.clear();
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                try {
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+       // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a
+       // static method)
+                    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101)      // unreferenced local variable
+                    const FatalConditionHandler fatalConditionHandler; // Handle signals
+                    static_cast<void>(fatalConditionHandler);
+                    // execute the test
+                    tc.m_test();
+                    FatalConditionHandler::reset();
+                    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                } catch (const TestFailureException &) {
+                    p->failure_flags |= TestCaseFailureReason::AssertFailure;
+                } catch (...) {
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {translateActiveException(), false});
+                    p->failure_flags |= TestCaseFailureReason::Exception;
+                }
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+                // exit this loop if enough assertions have failed - even if there are more subcases
+                if (p->abort_after > 0 &&
+                    p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
+                    run_test = false;
+                    p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
+                }
+
+                const bool has_next_path = run_test ? p->traversal.advance() : false;
+
+                if (has_next_path && run_test)
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
+                if (!has_next_path)
+                    run_test = false;
+            } while (run_test);
+
+            p->finalizeTestCaseData();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+            p->currentTest = nullptr;
+
+            // stop executing tests if enough assertions have failed
+            if (p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
+                break;
+        }
+    }
+
+    if (!query_mode) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    } else {
+        QueryData qdata;
+        qdata.run_stats = g_cs;
+        qdata.data = queryResults.data();
+        qdata.num_data = static_cast<unsigned>(queryResults.size());
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+    }
+
+    return cleanup_and_return();
+}
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+#ifndef DOCTEST_PARTS_PRIVATE_CONTEXT_SCOPE
+#define DOCTEST_PARTS_PRIVATE_CONTEXT_SCOPE
+
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+extern DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // DOCTEST_PARTS_PRIVATE_CONTEXT_SCOPE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+DOCTEST_DEFINE_INTERFACE(IContextScope)
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+
+ContextScopeBase::ContextScopeBase() {
+    g_infoContexts.push_back(this);
+}
+
+ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
+    if (other.need_to_destroy) {
+        other.destroy();
+    }
+    other.need_to_destroy = false;
+    g_infoContexts.push_back(this);
+}
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+// destroy cannot be inlined into the destructor because that would mean calling stringify after
+// ContextScope has been destroyed (base class destructors run after derived class destructors).
+// Instead, ContextScope calls this method directly from its destructor.
+void ContextScopeBase::destroy() {
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&                              \
+    (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+    if (std::uncaught_exceptions() > 0) {
+#else
+    if (std::uncaught_exception()) {
+#endif
+        std::ostringstream s;
+        this->stringify(&s);
+        g_cs->stringifiedContexts.emplace_back(s.str().c_str());
+    }
+    g_infoContexts.pop_back();
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+ContextState *g_cs = nullptr;
+DOCTEST_THREAD_LOCAL bool g_no_colors;
+
+void ContextState::resetRunData() {
+    numTestCases = 0;
+    numTestCasesPassingFilters = 0;
+    numTestSuitesPassingFilters = 0;
+    numTestCasesFailed = 0;
+    numAsserts = 0;
+    numAssertsFailed = 0;
+    numAssertsCurrentTest = 0;
+    numAssertsFailedCurrentTest = 0;
+}
+
+void ContextState::finalizeTestCaseData() {
+    seconds = timer.getElapsedSeconds();
+
+    // update the non-atomic counters
+    numAsserts += numAssertsCurrentTest_atomic;
+    numAssertsFailed += numAssertsFailedCurrentTest_atomic;
+    numAssertsCurrentTest = numAssertsCurrentTest_atomic;
+    numAssertsFailedCurrentTest = numAssertsFailedCurrentTest_atomic;
+
+    if (numAssertsFailedCurrentTest)
+        failure_flags |= TestCaseFailureReason::AssertFailure;
+
+    if (Approx(currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
+        Approx(seconds).epsilon(DBL_EPSILON) > currentTest->m_timeout)
+        failure_flags |= TestCaseFailureReason::Timeout;
+
+    if (currentTest->m_should_fail) {
+        if (failure_flags) {
+            failure_flags |= TestCaseFailureReason::ShouldHaveFailedAndDid;
+        } else {
+            failure_flags |= TestCaseFailureReason::ShouldHaveFailedButDidnt;
+        }
+    } else if (failure_flags && currentTest->m_may_fail) {
+        failure_flags |= TestCaseFailureReason::CouldHaveFailedAndDid;
+    } else if (currentTest->m_expected_failures > 0) {
+        if (numAssertsFailedCurrentTest == currentTest->m_expected_failures) {
+            failure_flags |= TestCaseFailureReason::FailedExactlyNumTimes;
+        } else {
+            failure_flags |= TestCaseFailureReason::DidntFailExactlyNumTimes;
+        }
+    }
+
+    const bool ok_to_fail = (TestCaseFailureReason::ShouldHaveFailedAndDid & failure_flags) ||
+                            (TestCaseFailureReason::CouldHaveFailedAndDid & failure_flags) ||
+                            (TestCaseFailureReason::FailedExactlyNumTimes & failure_flags);
+
+    // if any subcase has failed - the whole test case has failed
+    testCaseSuccess = !(failure_flags && !ok_to_fail);
+    if (!testCaseSuccess)
+        numTestCasesFailed++;
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+#ifdef DOCTEST_IS_DEBUGGER_ACTIVE
+bool isDebuggerActive() {
+    return DOCTEST_IS_DEBUGGER_ACTIVE();
+}
+#else // DOCTEST_IS_DEBUGGER_ACTIVE
+#ifdef DOCTEST_PLATFORM_LINUX
+class ErrnoGuard {
+public:
+    ErrnoGuard()
+        : m_oldErrno(errno) {}
+    ~ErrnoGuard() {
+        errno = m_oldErrno;
+    }
+
+private:
+    int m_oldErrno;
+};
+// See the comments in Catch2 for the reasoning behind this implementation:
+// https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
+bool isDebuggerActive() {
+    const ErrnoGuard guard;
+    std::ifstream in("/proc/self/status");
+    for (std::string line; std::getline(in, line);) {
+        static const int PREFIX_LEN = 11;
+        if (line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
+            return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
+        }
+    }
+    return false;
+}
+#elif defined(DOCTEST_PLATFORM_MAC)
+// The following function is taken directly from the following technical note:
+// https://developer.apple.com/library/archive/qa/qa1361/_index.html
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
+bool isDebuggerActive() {
+    int mib[4];
+    kinfo_proc info;
+    size_t size;
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+    info.kp_proc.p_flag = 0;
+    // Initialize mib, which tells sysctl the info we want, in this case
+    // we're looking for information about a specific process ID.
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+    // Call sysctl.
+    size = sizeof(info);
+    if (sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, nullptr, 0) != 0) {
+        std::cerr << "\nCall to sysctl failed - unable to determine if debugger is active **\n";
+        return false;
+    }
+    // We're being debugged if the P_TRACED flag is set.
+    return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}
+#elif DOCTEST_MSVC || defined(__MINGW32__) || defined(__MINGW64__)
+bool isDebuggerActive() {
+    return ::IsDebuggerPresent() != 0;
+}
+#else
+bool isDebuggerActive() {
+    return false;
+}
+#endif // Platform
+#endif // DOCTEST_IS_DEBUGGER_ACTIVE
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
+
+void registerExceptionTranslatorImpl(const IExceptionTranslator *et) noexcept {
+    if (std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
+        getExceptionTranslators().end())
+        getExceptionTranslators().push_back(et);
+}
+
+std::vector<const IExceptionTranslator *> &getExceptionTranslators() noexcept {
+    static std::vector<const IExceptionTranslator *> data;
+    return data;
+}
+
+String translateActiveException() noexcept {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+    String res;
+    auto &translators = getExceptionTranslators();
+    for (auto &curr: translators)
+        if (curr->translate(res))
+            return res;
+    // clang-format off
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
+    try {
+        throw;
+    } catch (std::exception &ex) {
+        return ex.what();
+    } catch (std::string &msg) {
+        return msg.c_str();
+    } catch (const char *msg) {
+        return msg;
+    } catch (...) {
+        return "unknown exception";
+    }
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+    // clang-format on
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+    return "";
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+bool checkIfShouldThrow(assertType::Enum at) {
+    if (at & assertType::is_require)
+        return true;
+
+    if ((at & assertType::is_check) && getContextOptions()->abort_after > 0 &&
+        (g_cs->numAssertsFailed + g_cs->numAssertsFailedCurrentTest_atomic) >= getContextOptions()->abort_after)
+        return true;
+
+    return false;
+}
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+DOCTEST_NORETURN void throwException() {
+    g_cs->shouldLogCurrentException = false;
+    throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
+}
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+void throwException() {}
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+
+int wildcmp(const char *str, const char *wild, bool caseSensitive) {
+    const char *cp = str;
+    const char *mp = wild;
+
+    while ((*str) && (*wild != '*')) {
+        if ((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) && (*wild != '?')) {
+            return 0;
+        }
+        wild++;
+        str++;
+    }
+
+    while (*str) {
+        if (*wild == '*') {
+            if (!*++wild) {
+                return 1;
+            }
+            mp = wild;
+            cp = str + 1;
+        } else if ((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) || (*wild == '?')) {
+            wild++;
+            str++;
+        } else {
+            wild = mp;
+            str = cp++;
+        }
+    }
+
+    while (*wild == '*') {
+        wild++;
+    }
+    return !*wild;
+}
+
+bool matchesAny(const char *name, const std::vector<String> &filters, bool matchEmpty, bool caseSensitive) {
+    if (filters.empty() && matchEmpty)
+        return true;
+    for (auto &curr: filters)
+        if (wildcmp(name, curr.c_str(), caseSensitive))
+            return true;
+    return false;
+}
+
+} // namespace detail
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) // 'function' : must be 'attribute' - see issue #182
+int main(int argc, char **argv) {
+    return doctest::Context(argc, argv).run();
+}
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+Approx::Approx(double value)
+    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value) {}
+
+Approx Approx::operator()(double value) const {
+    Approx approx(value);
+    approx.epsilon(m_epsilon);
+    approx.scale(m_scale);
+    return approx;
+}
+
+Approx &Approx::epsilon(double newEpsilon) {
+    m_epsilon = newEpsilon;
+    return *this;
+}
+Approx &Approx::scale(double newScale) {
+    m_scale = newScale;
+    return *this;
+}
+
+bool operator==(double lhs, const Approx &rhs) {
+    // Thanks to Richard Harris for his help refining this formula
+    return std::fabs(lhs - rhs.m_value) <
+           rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
+}
+
+bool operator==(const Approx &lhs, double rhs) {
+    return operator==(rhs, lhs);
+}
+
+bool operator!=(double lhs, const Approx &rhs) {
+    return !operator==(lhs, rhs);
+}
+
+bool operator!=(const Approx &lhs, double rhs) {
+    return !operator==(rhs, lhs);
+}
+
+bool operator<=(double lhs, const Approx &rhs) {
+    return lhs < rhs.m_value || lhs == rhs;
+}
+
+bool operator<=(const Approx &lhs, double rhs) {
+    return lhs.m_value < rhs || lhs == rhs;
+}
+
+bool operator>=(double lhs, const Approx &rhs) {
+    return lhs > rhs.m_value || lhs == rhs;
+}
+
+bool operator>=(const Approx &lhs, double rhs) {
+    return lhs.m_value > rhs || lhs == rhs;
+}
+
+bool operator<(double lhs, const Approx &rhs) {
+    return lhs < rhs.m_value && lhs != rhs;
+}
+
+bool operator<(const Approx &lhs, double rhs) {
+    return lhs.m_value < rhs && lhs != rhs;
+}
+
+bool operator>(double lhs, const Approx &rhs) {
+    return lhs > rhs.m_value && lhs != rhs;
+}
+
+bool operator>(const Approx &lhs, double rhs) {
+    return lhs.m_value > rhs && lhs != rhs;
+}
+
+String toString(const Approx &in) {
+    return "Approx( " + doctest::toString(in.m_value) + " )";
+}
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+Contains::Contains(const String &str)
+    : string(str) {}
+
+bool Contains::checkWith(const String &other) const {
+    return strstr(other.c_str(), string.c_str()) != nullptr;
+}
+
+String toString(const Contains &in) {
+    return "Contains( " + in.string + " )";
+}
+
+bool operator==(const String &lhs, const Contains &rhs) {
+    return rhs.checkWith(lhs);
+}
+
+bool operator==(const Contains &lhs, const String &rhs) {
+    return lhs.checkWith(rhs);
+}
+
+bool operator!=(const String &lhs, const Contains &rhs) {
+    return !rhs.checkWith(lhs);
+}
+
+bool operator!=(const Contains &lhs, const String &rhs) {
+    return !lhs.checkWith(rhs);
+}
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4738)
+template <typename F>
+IsNaN<F>::operator bool() const {
+    return std::isnan(value) ^ flipped;
+}
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+template struct DOCTEST_INTERFACE_DEF IsNaN<float>;
+template struct DOCTEST_INTERFACE_DEF IsNaN<double>;
+template struct DOCTEST_INTERFACE_DEF IsNaN<long double>;
+
+template <typename F>
+String toString(IsNaN<F> in) {
+    return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )";
+}
+
+String toString(IsNaN<float> in) {
+    return toString<float>(in);
+}
+
+String toString(IsNaN<double> in) {
+    return toString<double>(in);
+}
+
+String toString(IsNaN<double long> in) {
+    return toString<double long>(in);
+}
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR
+#define DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR ':'
+#endif
+
+namespace doctest {
+
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
+// depending on the current options this will remove the path of filenames
+const char *skipPathFromFilename(const char *file) {
+#ifndef DOCTEST_CONFIG_DISABLE
+    if (getContextOptions()->no_path_in_filenames) {
+        auto back = std::strrchr(file, '\\');
+        auto forward = std::strrchr(file, '/');
+        if (back || forward) {
+            if (back > forward)
+                forward = back;
+            return forward + 1;
+        }
+    } else {
+        const auto prefixes = getContextOptions()->strip_file_prefixes;
+        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
+        String::size_type longest_match = 0U;
+        for (String::size_type pos = 0U; pos < prefixes.size(); ++pos) {
+            const auto prefix_start = pos;
+            pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
+
+            const auto prefix_size = pos - prefix_start;
+            if (prefix_size > longest_match) {
+                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive
+                // letter capitalization?
+                if (0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size)) {
+                    longest_match = prefix_size;
+                }
+            }
+        }
+        return &file[longest_match];
+    }
+#endif // DOCTEST_CONFIG_DISABLE
+    return file;
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+#ifdef DOCTEST_CONFIG_DISABLE
+
+DOCTEST_DEFINE_INTERFACE(IReporter)
+
+int IReporter::get_num_active_contexts() {
+    return 0;
+}
+
+const IContextScope *const *IReporter::get_active_contexts() {
+    return nullptr;
+}
+
+int IReporter::get_num_stringified_contexts() {
+    return 0;
+}
+
+const String *IReporter::get_stringified_contexts() {
+    return nullptr;
+}
+
+int registerReporter(const char *, int, IReporter *) {
+    return 0;
+}
+
+#else
+
+namespace detail {
+reporterMap &getReporters() noexcept {
+    static reporterMap data;
+    return data;
+}
+
+reporterMap &getListeners() noexcept {
+    static reporterMap data;
+    return data;
+}
+} // namespace detail
+
+DOCTEST_DEFINE_INTERFACE(IReporter)
+
+int IReporter::get_num_active_contexts() {
+    return static_cast<int>(detail::g_infoContexts.size());
+}
+
+const IContextScope *const *IReporter::get_active_contexts() {
+    return get_num_active_contexts() ? detail::g_infoContexts.data() : nullptr;
+}
+
+int IReporter::get_num_stringified_contexts() {
+    return static_cast<int>(detail::g_cs->stringifiedContexts.size());
+}
+
+const String *IReporter::get_stringified_contexts() {
+    return get_num_stringified_contexts() ? detail::g_cs->stringifiedContexts.data() : nullptr;
+}
+
+namespace detail {
+void registerReporterImpl(const char *name, int priority, reporterCreatorFunc c, bool isReporter) noexcept {
+    if (isReporter)
+        getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+    else
+        getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+}
+} // namespace detail
+
+#endif // DOCTEST_CONFIG_DISABLE
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+void fulltext_log_assert_to_stream(std::ostream &s, const AssertData &rb) {
+    // clang-format off
+    if ((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) == 0)
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) " << Color::None;
+
+    if (rb.m_at & assertType::is_throws) {
+        s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
+    } else if ((rb.m_at & assertType::is_throws_as) && (rb.m_at & assertType::is_throws_with)) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", \"" << rb.m_exception_string.c_str() << "\", " << rb.m_exception_type
+          << " ) " << Color::None;
+
+        if (rb.m_threw) {
+            if (!rb.m_failed) {
+                s << "threw as expected!\n";
+            } else {
+                s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
+            }
+        } else {
+            s << "did NOT throw at all!\n";
+        }
+    } else if (rb.m_at & assertType::is_throws_as) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", " << rb.m_exception_type
+          << " ) " << Color::None
+          << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" : "threw a DIFFERENT exception: ") : "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_throws_with) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", \"" << rb.m_exception_string.c_str()
+          << "\" ) " << Color::None
+          << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" : "threw a DIFFERENT exception: ") : "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_nothrow) {
+        s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan << rb.m_exception << "\n";
+    } else {
+        s << (rb.m_threw ? "THREW exception: " : (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+        if (rb.m_threw)
+            s << rb.m_exception << "\n";
+        else
+            s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
+    }
+    // clang-format on
+}
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+using detail::g_cs;
+
+Whitespace::Whitespace(int nr)
+    : nrSpaces(nr) {}
+
+std::ostream &operator<<(std::ostream &out, const Whitespace &ws) {
+    if (ws.nrSpaces != 0)
+        out << std::setw(ws.nrSpaces) << ' ';
+    return out;
+}
+
+ConsoleReporter::ConsoleReporter(const ContextOptions &co)
+    : s(*co.cout), opt(co) {}
+
+ConsoleReporter::ConsoleReporter(const ContextOptions &co, std::ostream &ostr)
+    : s(ostr), opt(co) {}
+
+void ConsoleReporter::separator_to_stream() {
+    s << Color::Yellow
+      << "==============================================================================="
+         "\n";
+}
+
+const char *ConsoleReporter::getSuccessOrFailString(bool success, assertType::Enum at, const char *success_str) {
+    if (success)
+        return success_str;
+    return failureString(at);
+}
+
+Color::Enum ConsoleReporter::getSuccessOrFailColor(bool success, assertType::Enum at) {
+    return success ? Color::BrightGreen : (at & assertType::is_warn) ? Color::Yellow : Color::Red;
+}
+
+void ConsoleReporter::successOrFailColoredStringToStream(bool success, assertType::Enum at, const char *success_str) {
+    s << getSuccessOrFailColor(success, at) << getSuccessOrFailString(success, at, success_str) << ": ";
+}
+
+void ConsoleReporter::log_contexts() {
+    const int num_contexts = get_num_active_contexts();
+    if (num_contexts) {
+        auto contexts = get_active_contexts();
+
+        s << Color::None << "  logged: ";
+        for (int i = 0; i < num_contexts; ++i) {
+            s << (i == 0 ? "" : "          ");
+            contexts[i]->stringify(&s);
+            s << "\n";
+        }
+    }
+
+    s << "\n";
+}
+
+// this was requested to be made virtual so users could override it
+void ConsoleReporter::file_line_to_stream(const char *file, int line, const char *tail) {
+    s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
+      << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+      << (opt.gnu_file_line ? ":" : "):") << tail;
+}
+
+void ConsoleReporter::logTestStart() {
+    if (hasLoggedCurrentTestStart)
+        return;
+
+    separator_to_stream();
+    file_line_to_stream(tc->m_file.c_str(), static_cast<int>(tc->m_line), "\n");
+    if (tc->m_description)
+        s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
+    if (tc->m_test_suite && tc->m_test_suite[0] != '\0')
+        s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
+    if (strncmp(tc->m_name, "  Scenario:", 11) != 0)
+        s << Color::Yellow << "TEST CASE:  ";
+    s << Color::None << tc->m_name << "\n";
+
+    for (size_t i = 0; i < currentSubcaseLevel; ++i) {
+        if (subcasesStack[i].m_name[0] != '\0')
+            s << "  " << subcasesStack[i].m_name << "\n";
+    }
+
+    if (currentSubcaseLevel != subcasesStack.size()) {
+        s << Color::Yellow << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n" << Color::None;
+        for (size_t i = 0; i < subcasesStack.size(); ++i) {
+            if (subcasesStack[i].m_name[0] != '\0')
+                s << "  " << subcasesStack[i].m_name << "\n";
+        }
+    }
+
+    s << "\n";
+
+    hasLoggedCurrentTestStart = true;
+}
+
+void ConsoleReporter::printVersion() {
+    if (opt.no_version == false)
+        s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \"" << DOCTEST_VERSION_STR << "\"\n";
+}
+
+void ConsoleReporter::printIntro() {
+    if (opt.no_intro == false) {
+        printVersion();
+        s << Color::Cyan << "[doctest] " << Color::None
+          << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
+    }
+}
+
+void ConsoleReporter::printHelp() {
+    const int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
+    printVersion();
+    // clang-format off
+    s << Color::Cyan << "[doctest]\n" << Color::None;
+    s << Color::Cyan << "[doctest] " << Color::None;
+    s << "boolean values: \"1/on/yes/true\" or \"0/off/no/false\"\n";
+    s << Color::Cyan << "[doctest] " << Color::None;
+    s << "filter  values: \"str1,str2,str3\" (comma separated strings)\n";
+    s << Color::Cyan << "[doctest]\n" << Color::None;
+    s << Color::Cyan << "[doctest] " << Color::None;
+    s << "filters use wildcards for matching strings\n";
+    s << Color::Cyan << "[doctest] " << Color::None;
+    s << "something passes a filter if any of the strings in a filter matches\n";
+#ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+    s << Color::Cyan << "[doctest]\n" << Color::None;
+    s << Color::Cyan << "[doctest] " << Color::None;
+    s << "ALL FLAGS, OPTIONS AND FILTERS ALSO AVAILABLE WITH A \"" DOCTEST_CONFIG_OPTIONS_PREFIX "\" PREFIX!!!\n";
+#endif
+    s << Color::Cyan << "[doctest]\n" << Color::None;
+    s << Color::Cyan << "[doctest] " << Color::None;
+    s << "Query flags - the program quits after them. Available:\n\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "?,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "help, -" DOCTEST_OPTIONS_PREFIX_DISPLAY "h                      "
+      << Whitespace(sizePrefixDisplay * 0) <<  "prints this message\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "v,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "version                       "
+      << Whitespace(sizePrefixDisplay * 1) << "prints the version\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "c,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "count                         "
+      << Whitespace(sizePrefixDisplay * 1) << "prints the number of matching tests\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ltc, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-test-cases               "
+      << Whitespace(sizePrefixDisplay * 1) << "lists all matching tests by name\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "lts, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-test-suites              "
+      << Whitespace(sizePrefixDisplay * 1) << "lists all matching test suites\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "lr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-reporters                "
+      << Whitespace(sizePrefixDisplay * 1) << "lists all registered reporters\n\n";
+    // ================================================================================== << 79
+    s << Color::Cyan << "[doctest] " << Color::None;
+    s << "The available <int>/<string> options/filters are:\n\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-case=<filters>           "
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their name\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tce, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-case-exclude=<filters>   "
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their name\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sf,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "source-file=<filters>         "
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their file\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sfe, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "source-file-exclude=<filters> "
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their file\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ts,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-suite=<filters>          "
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their test suite\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tse, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-suite-exclude=<filters>  "
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their test suite\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase=<filters>             "
+      << Whitespace(sizePrefixDisplay * 1) << "filters     subcases by their name\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sce, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase-exclude=<filters>     "
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT subcases by their name\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "r,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "reporters=<filters>           "
+      << Whitespace(sizePrefixDisplay * 1) << "reporters to use (console is default)\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "o,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "out=<string>                  "
+      << Whitespace(sizePrefixDisplay * 1) << "output filename\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
+      << Whitespace(sizePrefixDisplay * 1) << "how the tests should be ordered\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       <string> - [file/suite/name/rand/none]\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "rs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "rand-seed=<int>               "
+      << Whitespace(sizePrefixDisplay * 1) << "seed for random ordering\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "f,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "first=<int>                   "
+      << Whitespace(sizePrefixDisplay * 1) << "the first test passing the filters to\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       execute - for range-based execution\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "l,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "last=<int>                    "
+      << Whitespace(sizePrefixDisplay * 1) << "the last test passing the filters to\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       execute - for range-based execution\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "aa,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "abort-after=<int>             "
+      << Whitespace(sizePrefixDisplay * 1) << "stop after <int> failed assertions\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "scfl,--" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase-filter-levels=<int>   "
+      << Whitespace(sizePrefixDisplay * 1) << "apply filters for the first <int> levels\n";
+    s << Color::Cyan << "\n[doctest] " << Color::None;
+    s << "Bool options - can be used like flags and true is assumed. Available:\n\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "s,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "success=<bool>                "
+      << Whitespace(sizePrefixDisplay * 1) << "include successful assertions in output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "cs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "case-sensitive=<bool>         "
+      << Whitespace(sizePrefixDisplay * 1) << "filters being treated as case sensitive\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "e,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "exit=<bool>                   "
+      << Whitespace(sizePrefixDisplay * 1) << "exits after the tests finish\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "d,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "duration=<bool>               "
+      << Whitespace(sizePrefixDisplay * 1) << "prints the time duration of each test\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "m,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "minimal=<bool>                "
+      << Whitespace(sizePrefixDisplay * 1) << "minimal console output (only failures)\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "q,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "quiet=<bool>                  "
+      << Whitespace(sizePrefixDisplay * 1) << "no console output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nt,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-throw=<bool>               "
+      << Whitespace(sizePrefixDisplay * 1) << "skips exceptions-related assert checks\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ne,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-exitcode=<bool>            "
+      << Whitespace(sizePrefixDisplay * 1) << "returns (or exits) always with success\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-run=<bool>                 "
+      << Whitespace(sizePrefixDisplay * 1) << "skips all runtime doctest operations\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ni,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-intro=<bool>               "
+      << Whitespace(sizePrefixDisplay * 1) << "omit the framework intro in the output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nv,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-version=<bool>             "
+      << Whitespace(sizePrefixDisplay * 1) << "omit the framework version in the output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-colors=<bool>              "
+      << Whitespace(sizePrefixDisplay * 1) << "disables colors in output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "fc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "force-colors=<bool>           "
+      << Whitespace(sizePrefixDisplay * 1) << "use colors even when not in a tty\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nb,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-breaks=<bool>              "
+      << Whitespace(sizePrefixDisplay * 1) << "disables breakpoints in debuggers\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ns,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-skip=<bool>                "
+      << Whitespace(sizePrefixDisplay * 1) << "don't skip test cases marked as skip\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "gfl, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "gnu-file-line=<bool>          "
+      << Whitespace(sizePrefixDisplay * 1) << ":n: vs (n): for line numbers in output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
+      << Whitespace(sizePrefixDisplay * 1) << "only filenames and no paths in output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sfp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "strip-file-prefixes=<p1:p2>   "
+      << Whitespace(sizePrefixDisplay * 1) << "whenever file paths start with this prefix, remove it from the output\n";
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
+      << Whitespace(sizePrefixDisplay * 1) << "0 instead of real line numbers in output\n";
+    // ================================================================================== << 79
+    // clang-format on
+
+    s << Color::Cyan << "\n[doctest] " << Color::None;
+    s << "for more information visit the project documentation\n\n";
+}
+
+void ConsoleReporter::printRegisteredReporters() {
+    printVersion();
+    auto printReporters = [this](const detail::reporterMap &reporters, const char *type) {
+        if (!reporters.empty()) {
+            s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
+            for (auto &curr: reporters)
+                s << "priority: " << std::setw(5) << curr.first.first << " name: " << curr.first.second << "\n";
+        }
+    };
+    printReporters(detail::getListeners(), "listeners");
+    printReporters(detail::getReporters(), "reporters");
+}
+
+void ConsoleReporter::report_query(const QueryData &in) {
+    if (opt.version) {
+        printVersion();
+    } else if (opt.help) {
+        printHelp();
+    } else if (opt.list_reporters) {
+        printRegisteredReporters();
+    } else if (opt.count || opt.list_test_cases) {
+        if (opt.list_test_cases) {
+            s << Color::Cyan << "[doctest] " << Color::None << "listing all test case names\n";
+            separator_to_stream();
+        }
+
+        for (unsigned i = 0; i < in.num_data; ++i)
+            s << Color::None << in.data[i]->m_name << "\n";
+
+        separator_to_stream();
+
+        s << Color::Cyan << "[doctest] " << Color::None
+          << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
+
+    } else if (opt.list_test_suites) {
+        s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
+        separator_to_stream();
+
+        for (unsigned i = 0; i < in.num_data; ++i)
+            s << Color::None << in.data[i]->m_test_suite << "\n";
+
+        separator_to_stream();
+
+        s << Color::Cyan << "[doctest] " << Color::None
+          << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
+        s << Color::Cyan << "[doctest] " << Color::None
+          << "test suites with unskipped test cases passing the current filters: " << g_cs->numTestSuitesPassingFilters
+          << "\n";
+    }
+}
+
+void ConsoleReporter::test_run_start() {
+    if (!opt.minimal)
+        printIntro();
+}
+
+void ConsoleReporter::test_run_end(const TestRunStats &p) {
+    if (opt.minimal && p.numTestCasesFailed == 0)
+        return;
+
+    separator_to_stream();
+    s << std::dec;
+
+    auto totwidth = static_cast<int>(std::ceil(
+        log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)
+    ));
+    auto passwidth = static_cast<int>(std::ceil(log10(
+        static_cast<double>(std::max(
+            p.numTestCasesPassingFilters - p.numTestCasesFailed,
+            static_cast<unsigned>(p.numAsserts - p.numAssertsFailed)
+        )) +
+        1
+    )));
+    auto failwidth = static_cast<int>(std::ceil(
+        log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)
+    ));
+    const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+    s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
+      << p.numTestCasesPassingFilters << " | "
+      << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(passwidth)
+      << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed" << Color::None << " | "
+      << (p.numTestCasesFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth) << p.numTestCasesFailed
+      << " failed" << Color::None << " |";
+    if (opt.no_skipped_summary == false) {
+        const unsigned int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
+        s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped << " skipped" << Color::None;
+    }
+    s << "\n";
+    s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth) << p.numAsserts << " | "
+      << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(passwidth)
+      << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None << " | "
+      << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth) << p.numAssertsFailed << " failed"
+      << Color::None << " |\n";
+    s << Color::Cyan << "[doctest] " << Color::None
+      << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
+      << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+}
+
+void ConsoleReporter::test_case_start(const TestCaseData &in) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    hasLoggedCurrentTestStart = false;
+    tc = &in;
+    subcasesStack.clear();
+    currentSubcaseLevel = 0;
+}
+
+void ConsoleReporter::test_case_reenter(const TestCaseData &) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    subcasesStack.clear();
+}
+
+void ConsoleReporter::test_case_end(const CurrentTestCaseStats &st) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    if (tc->m_no_output)
+        return;
+
+    // log the preamble of the test case only if there is something
+    // else to print - something other than that an assert has failed
+    if (opt.duration ||
+        (st.failure_flags && st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
+        logTestStart();
+
+    if (opt.duration)
+        s << Color::None << std::setprecision(6) << std::fixed << st.seconds << " s: " << tc->m_name << "\n";
+
+    if (st.failure_flags & TestCaseFailureReason::Timeout)
+        s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6) << std::fixed << tc->m_timeout
+          << "!\n";
+
+    if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+        s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
+    } else if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
+        s << Color::Yellow << "Failed as expected so marking it as not failed\n";
+    } else if (st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
+        s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
+    } else if (st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+        s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures << " times so marking it as failed!\n";
+    } else if (st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
+        s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
+          << " times as expected so marking it as not failed!\n";
+    }
+    if (st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+        s << Color::Red << "Aborting - too many failed asserts!\n";
+    }
+    s << Color::None;
+}
+
+void ConsoleReporter::test_case_exception(const TestCaseException &e) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    if (tc->m_no_output)
+        return;
+
+    logTestStart();
+
+    file_line_to_stream(tc->m_file.c_str(), static_cast<int>(tc->m_line), " ");
+    successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require : assertType::is_check);
+    s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ");
+    s << Color::Cyan << e.error_string << "\n";
+
+    const int num_stringified_contexts = get_num_stringified_contexts();
+    if (num_stringified_contexts) {
+        auto stringified_contexts = get_stringified_contexts();
+        s << Color::None << "  logged: ";
+        for (int i = num_stringified_contexts; i > 0; --i) {
+            s << (i == num_stringified_contexts ? "" : "          ") << stringified_contexts[i - 1] << "\n";
+        }
+    }
+    s << "\n" << Color::None;
+}
+
+void ConsoleReporter::subcase_start(const SubcaseSignature &subc) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    subcasesStack.push_back(subc);
+    ++currentSubcaseLevel;
+    hasLoggedCurrentTestStart = false;
+}
+
+void ConsoleReporter::subcase_end() {
+    DOCTEST_LOCK_MUTEX(mutex)
+    --currentSubcaseLevel;
+    hasLoggedCurrentTestStart = false;
+}
+
+void ConsoleReporter::log_assert(const AssertData &rb) {
+    if ((!rb.m_failed && !opt.success) || tc->m_no_output)
+        return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    logTestStart();
+
+    file_line_to_stream(rb.m_file, rb.m_line, " ");
+    successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
+
+    fulltext_log_assert_to_stream(s, rb);
+
+    log_contexts();
+}
+
+void ConsoleReporter::log_message(const MessageData &mb) {
+    if (tc->m_no_output)
+        return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    logTestStart();
+
+    file_line_to_stream(mb.m_file, mb.m_line, " ");
+    s << getSuccessOrFailColor(false, mb.m_severity)
+      << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity, "MESSAGE") << ": ";
+    s << Color::None << mb.m_string << "\n";
+    log_contexts();
+}
+
+void ConsoleReporter::test_case_skipped(const TestCaseData &) {}
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+#define DOCTEST_OUTPUT_DEBUG_STRING(text) ::OutputDebugStringA(text)
+#endif // Platform
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+
+DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
+
+DebugOutputWindowReporter::DebugOutputWindowReporter(const ContextOptions &co)
+    : ConsoleReporter(co, oss) {}
+
+#define DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(func, type, arg)                                                        \
+    void DebugOutputWindowReporter::func(type arg) {                                                                   \
+        using detail::g_no_colors;                                                                                     \
+        bool with_col = g_no_colors;                                                                                   \
+        g_no_colors = false;                                                                                           \
+        ConsoleReporter::func(arg);                                                                                    \
+        if (oss.tellp() != std::streampos{}) {                                                                         \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                                            \
+            oss.str("");                                                                                               \
+        }                                                                                                              \
+        g_no_colors = with_col;                                                                                        \
+    }
+
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_start, DOCTEST_EMPTY, DOCTEST_EMPTY)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_end, DOCTEST_EMPTY, DOCTEST_EMPTY)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_assert, const AssertData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_message, const MessageData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_skipped, const TestCaseData &, in)
+
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+std::string JUnitReporter::JUnitTestCaseData::getCurrentTimestamp() {
+    // Beware, this is not reentrant because of backward compatibility issues
+    // Also, UTC only, again because of backward compatibility (%z is C++11)
+    time_t rawtime{};
+    static_cast<void>(std::time(&rawtime));
+    const auto timeStampSize = sizeof("2017-01-16T17:06:45Z");
+
+    std::tm timeInfo;
+#if defined(DOCTEST_PLATFORM_WINDOWS)
+    gmtime_s(&timeInfo, &rawtime);
+#elif defined(__STDC_LIB_EXT1__)
+    gmtime_s(&rawtime, &timeInfo);
+#else  // DOCTEST_PLATFORM_WINDOWS
+    gmtime_r(&rawtime, &timeInfo);
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    char timeStamp[timeStampSize];
+    const char *const fmt = "%Y-%m-%dT%H:%M:%SZ";
+
+    static_cast<void>(std::strftime(timeStamp, timeStampSize, fmt, &timeInfo));
+    return std::string(timeStamp);
+}
+
+JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(
+    const std::string &_message, const std::string &_type, const std::string &_details
+)
+    : message(_message), type(_type), details(_details) {}
+
+JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(
+    const std::string &_message, const std::string &_details
+)
+    : message(_message), type(), details(_details) {}
+
+JUnitReporter::JUnitTestCaseData::JUnitTestCase::JUnitTestCase(const std::string &_classname, const std::string &_name)
+    : classname(_classname), name(_name), time(0), failures(), errors() {}
+
+void JUnitReporter::JUnitTestCaseData::add(const std::string &classname, const std::string &name) {
+    testcases.emplace_back(classname, name);
+}
+
+void JUnitReporter::JUnitTestCaseData::appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
+    for (auto &curr: nameStack)
+        if (curr.size())
+            testcases.back().name += std::string("/") + curr.c_str();
+}
+
+void JUnitReporter::JUnitTestCaseData::addTime(double time) {
+    if (time < 1e-4)
+        time = 0;
+    testcases.back().time = time;
+    totalSeconds += time;
+}
+
+void JUnitReporter::JUnitTestCaseData::addFailure(
+    const std::string &message, const std::string &type, const std::string &details
+) {
+    testcases.back().failures.emplace_back(message, type, details);
+    ++totalFailures;
+}
+
+void JUnitReporter::JUnitTestCaseData::addError(const std::string &message, const std::string &details) {
+    testcases.back().errors.emplace_back(message, details);
+    ++totalErrors;
+}
+
+JUnitReporter::JUnitReporter(const ContextOptions &co)
+    : xml(*co.cout), opt(co) {}
+
+unsigned JUnitReporter::line(unsigned l) const {
+    return opt.no_line_numbers ? 0 : l;
+}
+
+void JUnitReporter::report_query(const QueryData &) {
+    xml.writeDeclaration();
+}
+
+void JUnitReporter::test_run_start() {
+    xml.writeDeclaration();
+}
+
+void JUnitReporter::test_run_end(const TestRunStats &p) {
+    // remove .exe extension - mainly to have the same output on UNIX and Windows
+    // NOLINTNEXTLINE(misc-const-correctness)
+    std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if (binary_name.rfind(".exe") != std::string::npos)
+        binary_name = binary_name.substr(0, binary_name.length() - 4);
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    xml.startElement("testsuites");
+    xml.startElement("testsuite")
+        .writeAttribute("name", binary_name)
+        .writeAttribute("errors", testCaseData.totalErrors)
+        .writeAttribute("failures", testCaseData.totalFailures)
+        .writeAttribute("tests", p.numAsserts);
+    if (opt.no_time_in_output == false) {
+        xml.writeAttribute("time", testCaseData.totalSeconds);
+        xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
+    }
+    if (opt.no_version == false)
+        xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
+
+    for (const auto &testCase: testCaseData.testcases) {
+        xml.startElement("testcase")
+            .writeAttribute("classname", testCase.classname)
+            .writeAttribute("name", testCase.name);
+        if (opt.no_time_in_output == false)
+            xml.writeAttribute("time", testCase.time);
+        // This is not ideal, but it should be enough to mimic gtest's junit output.
+        xml.writeAttribute("status", "run");
+
+        for (const auto &failure: testCase.failures) {
+            xml.scopedElement("failure")
+                .writeAttribute("message", failure.message)
+                .writeAttribute("type", failure.type)
+                .writeText(failure.details, false);
+        }
+
+        for (const auto &error: testCase.errors) {
+            xml.scopedElement("error").writeAttribute("message", error.message).writeText(error.details);
+        }
+
+        xml.endElement();
+    }
+    xml.endElement();
+    xml.endElement();
+}
+
+void JUnitReporter::test_case_start(const TestCaseData &in) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+    timer.start();
+    tc = &in;
+}
+
+void JUnitReporter::test_case_reenter(const TestCaseData &in) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    testCaseData.addTime(timer.getElapsedSeconds());
+    testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+    deepestSubcaseStackNames.clear();
+
+    timer.start();
+    testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+    tc = &in;
+}
+
+void JUnitReporter::test_case_end(const CurrentTestCaseStats &st) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    testCaseData.addTime(timer.getElapsedSeconds());
+    testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+    deepestSubcaseStackNames.clear();
+
+    if (st.failure_flags & TestCaseFailureReason::Timeout) {
+        auto *stream = detail::tlssPush();
+        *stream << "Test case exceeded time limit of " << std::setprecision(6) << std::fixed << tc->m_timeout;
+        testCaseData.addError("timeout", detail::tlssPop().c_str());
+    }
+
+    if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+        testCaseData.addError("should_fail", "Should have failed, but didn't");
+    } else if (st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+        auto *stream = detail::tlssPush();
+        *stream << "Should have failed exactly " << tc->m_expected_failures << " times, but didn't";
+        testCaseData.addError("should_fail", detail::tlssPop().c_str());
+    }
+
+    if (st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+        testCaseData.addError("abort_after", "Too many failed asserts");
+    }
+
+    tc = nullptr;
+}
+
+void JUnitReporter::test_case_exception(const TestCaseException &e) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    testCaseData.addError("exception", e.error_string.c_str());
+}
+
+void JUnitReporter::subcase_start(const SubcaseSignature &in) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    deepestSubcaseStackNames.push_back(in.m_name);
+}
+
+void JUnitReporter::subcase_end() {}
+
+void JUnitReporter::log_assert(const AssertData &rb) {
+    if (!rb.m_failed) // report only failures & ignore the `success` option
+        return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    std::ostringstream os;
+    os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(rb.m_line)
+       << (opt.gnu_file_line ? ":" : "):") << std::endl;
+
+    fulltext_log_assert_to_stream(os, rb);
+    log_contexts(os);
+    testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
+}
+
+void JUnitReporter::log_message(const MessageData &mb) {
+    if (mb.m_severity & assertType::is_warn) // report only failures
+        return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    std::ostringstream os;
+    os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(mb.m_line)
+       << (opt.gnu_file_line ? ":" : "):") << std::endl;
+
+    os << mb.m_string.c_str() << "\n";
+    log_contexts(os);
+
+    testCaseData.addFailure(
+        mb.m_string.c_str(), mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str()
+    );
+}
+
+void JUnitReporter::test_case_skipped(const TestCaseData &) {}
+
+void JUnitReporter::log_contexts(std::ostringstream &s) {
+    const int num_contexts = get_num_active_contexts();
+    if (num_contexts) {
+        auto contexts = get_active_contexts();
+
+        s << "  logged: ";
+        for (int i = 0; i < num_contexts; ++i) {
+            s << (i == 0 ? "" : "          ");
+            contexts[i]->stringify(&s);
+            s << std::endl;
+        }
+    }
+}
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+XmlReporter::XmlReporter(const ContextOptions &co)
+    : xml(*co.cout), opt(co) {}
+
+void XmlReporter::log_contexts() {
+    const int num_contexts = get_num_active_contexts();
+    if (num_contexts) {
+        auto contexts = get_active_contexts();
+        std::stringstream ss;
+        for (int i = 0; i < num_contexts; ++i) {
+            contexts[i]->stringify(&ss);
+            xml.scopedElement("Info").writeText(ss.str());
+            ss.str("");
+        }
+    }
+}
+
+unsigned XmlReporter::line(unsigned l) const {
+    return opt.no_line_numbers ? 0 : l;
+}
+
+void XmlReporter::test_case_start_impl(const TestCaseData &in) {
+    bool open_ts_tag = false;
+    if (tc != nullptr) { // we have already opened a test suite
+        if (std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
+            xml.endElement();
+            open_ts_tag = true;
+        }
+    } else {
+        open_ts_tag = true; // first test case ==> first test suite
+    }
+
+    if (open_ts_tag) {
+        xml.startElement("TestSuite");
+        xml.writeAttribute("name", in.m_test_suite);
+    }
+
+    tc = &in;
+    xml.startElement("TestCase")
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
+        .writeAttribute("line", line(in.m_line))
+        .writeAttribute("description", in.m_description);
+
+    if (Approx(in.m_timeout) != 0)
+        xml.writeAttribute("timeout", in.m_timeout);
+    if (in.m_may_fail)
+        xml.writeAttribute("may_fail", true);
+    if (in.m_should_fail)
+        xml.writeAttribute("should_fail", true);
+}
+
+void XmlReporter::report_query(const QueryData &in) {
+    test_run_start();
+    if (opt.list_reporters) {
+        for (auto &curr: detail::getListeners())
+            xml.scopedElement("Listener")
+                .writeAttribute("priority", curr.first.first)
+                .writeAttribute("name", curr.first.second);
+        for (auto &curr: detail::getReporters())
+            xml.scopedElement("Reporter")
+                .writeAttribute("priority", curr.first.first)
+                .writeAttribute("name", curr.first.second);
+    } else if (opt.count || opt.list_test_cases) {
+        for (unsigned i = 0; i < in.num_data; ++i) {
+            xml.scopedElement("TestCase")
+                .writeAttribute("name", in.data[i]->m_name)
+                .writeAttribute("testsuite", in.data[i]->m_test_suite)
+                .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file.c_str()))
+                .writeAttribute("line", line(in.data[i]->m_line))
+                .writeAttribute("skipped", in.data[i]->m_skip);
+        }
+        xml.scopedElement("OverallResultsTestCases")
+            .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+    } else if (opt.list_test_suites) {
+        for (unsigned i = 0; i < in.num_data; ++i)
+            xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
+        xml.scopedElement("OverallResultsTestCases")
+            .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+        xml.scopedElement("OverallResultsTestSuites")
+            .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
+    }
+    xml.endElement();
+}
+
+void XmlReporter::test_run_start() {
+    xml.writeDeclaration();
+
+    // remove .exe extension - mainly to have the same output on UNIX and Windows
+    // NOLINTNEXTLINE(misc-const-correctness)
+    std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if (binary_name.rfind(".exe") != std::string::npos)
+        binary_name = binary_name.substr(0, binary_name.length() - 4);
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    xml.startElement("doctest").writeAttribute("binary", binary_name);
+    if (opt.no_version == false)
+        xml.writeAttribute("version", DOCTEST_VERSION_STR);
+
+    // only the consequential ones (TODO: filters)
+    xml.scopedElement("Options")
+        .writeAttribute("order_by", opt.order_by.c_str())
+        .writeAttribute("rand_seed", opt.rand_seed)
+        .writeAttribute("first", opt.first)
+        .writeAttribute("last", opt.last)
+        .writeAttribute("abort_after", opt.abort_after)
+        .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
+        .writeAttribute("case_sensitive", opt.case_sensitive)
+        .writeAttribute("no_throw", opt.no_throw)
+        .writeAttribute("no_skip", opt.no_skip);
+}
+
+void XmlReporter::test_run_end(const TestRunStats &p) {
+    if (tc) // the TestSuite tag - only if there has been at least 1 test case
+        xml.endElement();
+
+    xml.scopedElement("OverallResultsAsserts")
+        .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
+        .writeAttribute("failures", p.numAssertsFailed);
+
+    xml.startElement("OverallResultsTestCases")
+        .writeAttribute("successes", p.numTestCasesPassingFilters - p.numTestCasesFailed)
+        .writeAttribute("failures", p.numTestCasesFailed);
+    if (opt.no_skipped_summary == false)
+        xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
+    xml.endElement();
+
+    xml.endElement();
+}
+
+void XmlReporter::test_case_start(const TestCaseData &in) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    test_case_start_impl(in);
+    xml.ensureTagClosed();
+}
+
+void XmlReporter::test_case_reenter(const TestCaseData &) {}
+
+void XmlReporter::test_case_end(const CurrentTestCaseStats &st) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    xml.startElement("OverallResultsAsserts")
+        .writeAttribute("successes", st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
+        .writeAttribute("failures", st.numAssertsFailedCurrentTest)
+        .writeAttribute("test_case_success", st.testCaseSuccess);
+    if (opt.duration)
+        xml.writeAttribute("duration", st.seconds);
+    if (tc->m_expected_failures)
+        xml.writeAttribute("expected_failures", tc->m_expected_failures);
+    xml.endElement();
+
+    xml.endElement();
+}
+
+void XmlReporter::test_case_exception(const TestCaseException &e) {
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    xml.scopedElement("Exception").writeAttribute("crash", e.is_crash).writeText(e.error_string.c_str());
+}
+
+void XmlReporter::subcase_start(const SubcaseSignature &in) {
+    DOCTEST_LOCK_MUTEX(mutex)
+    xml.startElement("SubCase")
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file))
+        .writeAttribute("line", line(in.m_line));
+    xml.ensureTagClosed();
+}
+
+void XmlReporter::subcase_end() {
+    DOCTEST_LOCK_MUTEX(mutex)
+    xml.endElement();
+}
+
+void XmlReporter::log_assert(const AssertData &rb) {
+    if (!rb.m_failed && !opt.success)
+        return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    xml.startElement("Expression")
+        .writeAttribute("success", !rb.m_failed)
+        .writeAttribute("type", assertString(rb.m_at))
+        .writeAttribute("filename", skipPathFromFilename(rb.m_file))
+        .writeAttribute("line", line(rb.m_line));
+
+    xml.scopedElement("Original").writeText(rb.m_expr);
+
+    if (rb.m_threw)
+        xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
+
+    if (rb.m_at & assertType::is_throws_as)
+        xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
+    if (rb.m_at & assertType::is_throws_with)
+        xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
+    if ((rb.m_at & assertType::is_normal) && !rb.m_threw)
+        xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
+
+    log_contexts();
+
+    xml.endElement();
+}
+
+void XmlReporter::log_message(const MessageData &mb) {
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    xml.startElement("Message")
+        .writeAttribute("type", failureString(mb.m_severity))
+        .writeAttribute("filename", skipPathFromFilename(mb.m_file))
+        .writeAttribute("line", line(mb.m_line));
+
+    xml.scopedElement("Text").writeText(mb.m_string.c_str());
+
+    log_contexts();
+
+    xml.endElement();
+}
+
+void XmlReporter::test_case_skipped(const TestCaseData &in) {
+    if (opt.no_skipped_summary == false) {
+        DOCTEST_LOCK_MUTEX(mutex)
+        test_case_start_impl(in);
+        xml.writeAttribute("skipped", "true");
+        xml.endElement();
+    }
+}
+
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
+void FatalConditionHandler::reset() {}
+void FatalConditionHandler::allocateAltStackMem() {}
+void FatalConditionHandler::freeAltStackMem() {}
+#else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+
+// There is no 1-1 mapping between signals and windows exceptions.
+// Windows can easily distinguish between SO and SigSegV,
+// but SigInt, SigTerm, etc are handled differently.
+SignalDefs signalDefs[] = {
+    {static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION), "SIGILL - Illegal instruction signal"},
+    {static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow"},
+    {static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION), "SIGSEGV - Segmentation violation signal"},
+    {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
+};
+
+LONG CALLBACK FatalConditionHandler::handleException(PEXCEPTION_POINTERS ExceptionInfo) {
+    // Multiple threads may enter this filter/handler at once. We want the error message to be
+    // printed on the console just once no matter how many threads have crashed.
+    DOCTEST_DECLARE_STATIC_MUTEX(mutex)
+    static bool execute = true;
+    {
+        DOCTEST_LOCK_MUTEX(mutex)
+        if (execute) {
+            bool reported = false;
+            for (size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+                if (ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+                    reportFatal(signalDefs[i].name);
+                    reported = true;
+                    break;
+                }
+            }
+            if (reported == false)
+                reportFatal("Unhandled SEH exception caught");
+            if (isDebuggerActive() && !g_cs->no_breaks)
+                DOCTEST_BREAK_INTO_DEBUGGER();
+        }
+        execute = false;
+    }
+    std::exit(EXIT_FAILURE);
+}
+
+void FatalConditionHandler::allocateAltStackMem() {}
+void FatalConditionHandler::freeAltStackMem() {}
+
+FatalConditionHandler::FatalConditionHandler() {
+    isSet = true;
+    // 32k seems enough for doctest to handle stack overflow,
+    // but the value was found experimentally, so there is no strong guarantee
+    guaranteeSize = 32 * 1024;
+    // Register an unhandled exception filter
+    previousTop = SetUnhandledExceptionFilter(handleException);
+    // Pass in guarantee size to be filled
+    SetThreadStackGuarantee(&guaranteeSize);
+
+    // On Windows uncaught exceptions from another thread, exceptions from
+    // destructors, or calls to std::terminate are not a SEH exception
+
+    // The terminal handler gets called when:
+    // - std::terminate is called FROM THE TEST RUNNER THREAD
+    // - an exception is thrown from a destructor FROM THE TEST RUNNER THREAD
+    original_terminate_handler = std::get_terminate();
+    std::set_terminate([]() DOCTEST_NOEXCEPT {
+        reportFatal("Terminate handler called");
+        if (isDebuggerActive() && !g_cs->no_breaks)
+            DOCTEST_BREAK_INTO_DEBUGGER();
+        std::exit(EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
+    });
+
+    // SIGABRT is raised when:
+    // - std::terminate is called FROM A DIFFERENT THREAD
+    // - an exception is thrown from a destructor FROM A DIFFERENT THREAD
+    // - an uncaught exception is thrown FROM A DIFFERENT THREAD
+    prev_sigabrt_handler = std::signal(SIGABRT, [](int signal) DOCTEST_NOEXCEPT {
+        if (signal == SIGABRT) {
+            reportFatal("SIGABRT - Abort (abnormal termination) signal");
+            if (isDebuggerActive() && !g_cs->no_breaks)
+                DOCTEST_BREAK_INTO_DEBUGGER();
+            std::exit(EXIT_FAILURE);
+        }
+    });
+
+    // The following settings are taken from google test, and more
+    // specifically from UnitTest::Run() inside of gtest.cc
+
+    // the user does not want to see pop-up dialogs about crashes
+    prev_error_mode_1 = SetErrorMode(
+        SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX
+    );
+    // This forces the abort message to go to stderr in all circumstances.
+    prev_error_mode_2 = _set_error_mode(_OUT_TO_STDERR);
+    // In the debug version, Visual Studio pops up a separate dialog
+    // offering a choice to debug the aborted program - we want to disable that.
+    prev_abort_behavior = _set_abort_behavior(0x0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    // In debug mode, the Windows CRT can crash with an assertion over invalid
+    // input (e.g. passing an invalid file descriptor). The default handling
+    // for these assertions is to pop up a dialog and wait for user input.
+    // Instead ask the CRT to dump such assertions to stderr non-interactively.
+    prev_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    prev_report_file = _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+}
+
+void FatalConditionHandler::reset() {
+    if (isSet) {
+        // Unregister handler and restore the old guarantee
+        SetUnhandledExceptionFilter(previousTop);
+        SetThreadStackGuarantee(&guaranteeSize);
+        std::set_terminate(original_terminate_handler);
+        std::signal(SIGABRT, prev_sigabrt_handler);
+        SetErrorMode(prev_error_mode_1);
+        _set_error_mode(prev_error_mode_2);
+        _set_abort_behavior(prev_abort_behavior, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+        static_cast<void>(_CrtSetReportMode(_CRT_ASSERT, prev_report_mode));
+        static_cast<void>(_CrtSetReportFile(_CRT_ASSERT, prev_report_file));
+        isSet = false;
+    }
+}
+
+FatalConditionHandler::~FatalConditionHandler() {
+    reset();
+}
+
+UINT FatalConditionHandler::prev_error_mode_1;
+int FatalConditionHandler::prev_error_mode_2;
+unsigned int FatalConditionHandler::prev_abort_behavior;
+int FatalConditionHandler::prev_report_mode;
+_HFILE FatalConditionHandler::prev_report_file;
+void(DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
+std::terminate_handler FatalConditionHandler::original_terminate_handler;
+bool FatalConditionHandler::isSet = false;
+ULONG FatalConditionHandler::guaranteeSize = 0;
+LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
+
+#else // DOCTEST_PLATFORM_WINDOWS
+
+SignalDefs signalDefs[] = {
+    {SIGINT, "SIGINT - Terminal interrupt signal"},
+    {SIGILL, "SIGILL - Illegal instruction signal"},
+    {SIGFPE, "SIGFPE - Floating point error signal"},
+    {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
+    {SIGTERM, "SIGTERM - Termination request signal"},
+    {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}
+};
+static_assert(
+    DOCTEST_COUNTOF(signalDefs) == DOCTEST_COUNTOF(FatalConditionHandler::oldSigActions), "arrays should match in size"
+);
+
+void FatalConditionHandler::handleSignal(int sig) {
+    const char *name = "<unknown signal>";
+    for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+        const SignalDefs &def = signalDefs[i];
+        if (sig == def.id) {
+            name = def.name;
+            break;
+        }
+    }
+    reset();
+    reportFatal(name);
+    static_cast<void>(raise(sig));
+}
+
+void FatalConditionHandler::allocateAltStackMem() {
+    altStackMem = new char[altStackSize];
+}
+
+void FatalConditionHandler::freeAltStackMem() {
+    delete[] altStackMem;
+}
+
+FatalConditionHandler::FatalConditionHandler() {
+    isSet = true;
+    stack_t sigStack;
+    sigStack.ss_sp = altStackMem;
+    sigStack.ss_size = altStackSize;
+    sigStack.ss_flags = 0;
+    sigaltstack(&sigStack, &oldSigStack);
+    struct sigaction sa = {};
+    sa.sa_handler = handleSignal;
+    sa.sa_flags = SA_ONSTACK;
+    for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+        sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
+    }
+}
+
+FatalConditionHandler::~FatalConditionHandler() {
+    reset();
+}
+
+void FatalConditionHandler::reset() {
+    if (isSet) {
+        // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
+        for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+            sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
+        }
+        // Return the old stack
+        sigaltstack(&oldSigStack, nullptr);
+        isSet = false;
+    }
+}
+
+bool FatalConditionHandler::isSet = false;
+struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
+stack_t FatalConditionHandler::oldSigStack = {};
+size_t FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
+char *FatalConditionHandler::altStackMem = nullptr;
+
+#endif // DOCTEST_PLATFORM_WINDOWS
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+namespace detail {
+
+DOCTEST_THREAD_LOCAL class oss {
+    std::vector<std::streampos> stack;
+    std::stringstream ss;
+
+public:
+    std::ostream *push() {
+        stack.push_back(ss.tellp());
+        return &ss;
+    }
+
+    String pop() {
+        if (stack.empty())
+            DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
+
+        const std::streampos pos = stack.back();
+        stack.pop_back();
+        const unsigned sz = static_cast<unsigned>(ss.tellp() - pos);
+        ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
+        return String(ss, sz);
+    }
+} g_oss; // NOLINT(bugprone-throwing-static-initialization, cert-err58-cpp)
+
+std::ostream *tlssPush() {
+    return g_oss.push();
+}
+
+String tlssPop() {
+    return g_oss.pop();
+}
+
+} // namespace detail
+
+// case insensitive strcmp
+static int stricmp(const char *a, const char *b) {
+    for (;; a++, b++) {
+        const int d = tolower(*a) - tolower(*b);
+        if (d != 0 || !*a)
+            return d;
+    }
+}
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+
+char *String::allocate(size_type sz) {
+    if (sz <= last) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+        return buf;
+    } else {
+        setOnHeap();
+        data.size = sz;
+        data.capacity = data.size + 1;
+        data.ptr = new char[data.capacity];
+        data.ptr[sz] = '\0';
+        return data.ptr;
+    }
+}
+
+void String::setOnHeap() noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    *reinterpret_cast<unsigned char *>(&buf[last]) = 128;
+}
+
+void String::setLast(size_type in) noexcept {
+    buf[last] = static_cast<char>(in);
+}
+
+void String::setSize(size_type sz) noexcept {
+    if (isOnStack()) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+    } else {
+        data.ptr[sz] = '\0';
+        data.size = sz;
+    }
+}
+
+void String::copy(const String &other) {
+    if (other.isOnStack()) {
+        memcpy(buf, other.buf, len);
+    } else {
+        memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
+    }
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+String::String() noexcept {
+    buf[0] = '\0';
+    setLast();
+}
+
+String::~String() {
+    if (!isOnStack())
+        delete[] data.ptr;
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+String::String(const char *in)
+    : String(in, strlen(in)) {}
+
+String::String(const char *in, size_type in_size) {
+    memcpy(allocate(in_size), in, in_size);
+}
+
+String::String(std::istream &in, size_type in_size) {
+    in.read(allocate(in_size), in_size);
+}
+
+String::String(const String &other) {
+    copy(other);
+}
+
+String &String::operator=(const String &other) {
+    if (this != &other) {
+        if (!isOnStack())
+            delete[] data.ptr;
+
+        copy(other);
+    }
+
+    return *this;
+}
+
+String &String::operator+=(const String &other) {
+    const size_type my_old_size = size();
+    const size_type other_size = other.size();
+    const size_type total_size = my_old_size + other_size;
+    if (isOnStack()) {
+        if (total_size < len) {
+            // append to the current stack space
+            memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+            setLast(last - total_size);
+        } else {
+            // alloc new chunk
+            char *temp = new char[total_size + 1];
+            // copy current data to new location before writing in the union
+            memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+            // update data in union
+            setOnHeap();
+            data.size = total_size;
+            data.capacity = data.size + 1;
+            data.ptr = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
+    } else {
+        if (data.capacity > total_size) {
+            // append to the current heap block
+            data.size = total_size;
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        } else {
+            // resize
+            data.capacity *= 2;
+            if (data.capacity <= total_size)
+                data.capacity = total_size + 1;
+            // alloc new chunk
+            char *temp = new char[data.capacity];
+            // copy current data to new location before releasing it
+            memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+            // release old chunk
+            delete[] data.ptr;
+            // update the rest of the union members
+            data.size = total_size;
+            data.ptr = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
+    }
+
+    return *this;
+}
+
+String::String(String &&other) noexcept {
+    memcpy(buf, other.buf, len);
+    other.buf[0] = '\0';
+    other.setLast();
+}
+
+String &String::operator=(String &&other) noexcept {
+    if (this != &other) {
+        if (!isOnStack())
+            delete[] data.ptr;
+        memcpy(buf, other.buf, len);
+        other.buf[0] = '\0';
+        other.setLast();
+    }
+    return *this;
+}
+
+char String::operator[](size_type i) const {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<String *>(this)->operator[](i);
+}
+
+char &String::operator[](size_type i) {
+    if (isOnStack())
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return reinterpret_cast<char *>(buf)[i];
+    return data.ptr[i];
+}
+
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
+String::size_type String::size() const {
+    if (isOnStack())
+        return last - (static_cast<size_type>(buf[last]) & 31); // using "last" would work only if "len" is 32
+    return data.size;
+}
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+String::size_type String::capacity() const {
+    if (isOnStack())
+        return len;
+    return data.capacity;
+}
+
+String String::substr(size_type pos, size_type cnt) && {
+    cnt = std::min(cnt, size() - pos);
+    char *cptr = c_str();
+    memmove(cptr, cptr + pos, cnt);
+    setSize(cnt);
+    return std::move(*this);
+}
+
+String String::substr(size_type pos, size_type cnt) const & {
+    cnt = std::min(cnt, size() - pos);
+    return String{c_str() + pos, cnt};
+}
+
+String::size_type String::find(char ch, size_type pos) const {
+    const char *begin = c_str();
+    const char *end = begin + size();
+    const char *it = begin + pos;
+    for (; it < end && *it != ch; it++) {}
+    if (it < end) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
+    }
+}
+
+String::size_type String::rfind(char ch, size_type pos) const {
+    if (size() == 0) {
+        return npos;
+    }
+
+    const char *begin = c_str();
+    const char *it = begin + std::min(pos, size() - 1);
+    for (; it >= begin && *it != ch; it--) {}
+    if (it >= begin) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
+    }
+}
+
+int String::compare(const char *other, bool no_case) const {
+    if (no_case)
+        return doctest::stricmp(c_str(), other);
+    return std::strcmp(c_str(), other);
+}
+
+int String::compare(const String &other, bool no_case) const {
+    return compare(other.c_str(), no_case);
+}
+
+String operator+(const String &lhs, const String &rhs) {
+    return String(lhs) += rhs;
+}
+
+bool operator==(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) == 0;
+}
+
+bool operator!=(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) != 0;
+}
+
+bool operator<(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) < 0;
+}
+
+bool operator>(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) > 0;
+}
+
+bool operator<=(const String &lhs, const String &rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) < 0 : true;
+}
+
+bool operator>=(const String &lhs, const String &rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) > 0 : true;
+}
+
+std::ostream &operator<<(std::ostream &s, const String &in) {
+    return s << in.c_str();
+}
+
+namespace detail {
+
+void filldata<const void *>::fill(std::ostream *stream, const void *in) {
+    filldata<const volatile void *>::fill(stream, in);
+}
+
+void filldata<const volatile void *>::fill(std::ostream *stream, const volatile void *in) {
+    if (in) {
+        *stream << in;
+    } else {
+        *stream << "nullptr";
+    }
+}
+
+template <typename T>
+String toStreamLit(T t) {
+    // NOLINTNEXTLINE(misc-const-correctness)
+    std::ostream *os = tlssPush();
+    os->operator<<(t);
+    return tlssPop();
+}
+} // namespace detail
+
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+String toString(const char *in) {
+    return String("\"") + (in ? in : "{null string}") + "\"";
+}
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+String toString(const std::string &in) {
+    return in.c_str();
+}
+#endif // VS 2019
+
+String toString(const String &in) {
+    return in;
+}
+
+String toString(std::nullptr_t) {
+    return "nullptr";
+}
+
+String toString(bool in) {
+    return in ? "true" : "false";
+}
+
+String toString(float in) {
+    return detail::toStreamLit(in);
+}
+String toString(double in) {
+    return detail::toStreamLit(in);
+}
+String toString(double long in) {
+    return detail::toStreamLit(in);
+}
+
+String toString(char in) {
+    return detail::toStreamLit(static_cast<signed>(in));
+}
+String toString(char signed in) {
+    return detail::toStreamLit(static_cast<signed>(in));
+}
+String toString(char unsigned in) {
+    return detail::toStreamLit(static_cast<unsigned>(in));
+}
+String toString(short in) {
+    return detail::toStreamLit(in);
+}
+String toString(short unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(signed in) {
+    return detail::toStreamLit(in);
+}
+String toString(unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(long in) {
+    return detail::toStreamLit(in);
+}
+String toString(long unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(long long in) {
+    return detail::toStreamLit(in);
+}
+String toString(long long unsigned in) {
+    return detail::toStreamLit(in);
+}
+
+// NOLINTEND(cppcoreguidelines-pro-type-union-access)
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+namespace doctest {
+
+bool SubcaseSignature::operator==(const SubcaseSignature &other) const {
+    return m_line == other.m_line && std::strcmp(m_file, other.m_file) == 0 && m_name == other.m_name;
+}
+
+bool SubcaseSignature::operator<(const SubcaseSignature &other) const {
+    if (m_line != other.m_line)
+        return m_line < other.m_line;
+    if (std::strcmp(m_file, other.m_file) != 0)
+        return std::strcmp(m_file, other.m_file) < 0;
+    return m_name.compare(other.m_name) < 0;
+}
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+
+bool Subcase::checkFilters() {
+    if (g_cs->traversal.activeSubcaseDepth() < static_cast<size_t>(g_cs->subcase_filter_levels)) {
+        if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+            return true;
+        if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+            return true;
+    }
+    return false;
+}
+
+Subcase::Subcase(const String &name, const char *file, int line)
+    : m_signature({name, file, line}) {
+    if (checkFilters())
+        return;
+
+    if (!g_cs->traversal.tryEnterSubcase(m_signature))
+        return;
+
+    m_entered = true;
+    DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+}
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
+Subcase::~Subcase() {
+    if (m_entered) {
+        g_cs->traversal.leaveSubcase();
+
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&                              \
+    (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+        if (std::uncaught_exceptions() > 0
+#else
+        if (std::uncaught_exception()
+#endif
+            && g_cs->shouldLogCurrentException) {
+            DOCTEST_ITERATE_THROUGH_REPORTERS(
+                test_case_exception,
+                {"exception thrown in subcase - will translate later "
+                 "when the whole test case has been exited (cannot "
+                 "translate while there is an active exception)",
+                 false}
+            );
+            g_cs->shouldLogCurrentException = false;
+        }
+
+        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+    }
+}
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+Subcase::operator bool() const {
+    return m_entered;
+}
+
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+std::set<TestCase> &getRegisteredTests() {
+    static std::set<TestCase> data;
+    return data;
+}
+
+TestCase::TestCase(
+    funcType test, const char *file, unsigned line, const TestSuite &test_suite, const String &type, int template_id
+) noexcept {
+    m_file = file;
+    m_line = line;
+    m_name = nullptr; // will be later overridden in operator*
+    m_test_suite = test_suite.m_test_suite;
+    m_description = test_suite.m_description;
+    m_skip = test_suite.m_skip;
+    m_no_breaks = test_suite.m_no_breaks;
+    m_no_output = test_suite.m_no_output;
+    m_may_fail = test_suite.m_may_fail;
+    m_should_fail = test_suite.m_should_fail;
+    m_expected_failures = test_suite.m_expected_failures;
+    m_timeout = test_suite.m_timeout;
+
+    m_test = test;
+    m_type = type;
+    m_template_id = template_id;
+}
+
+TestCase::TestCase(const TestCase &other) noexcept // NOLINT(bugprone-copy-constructor-init)
+    : TestCaseData() {
+    *this = other;
+}
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434)                  // hides a non-virtual function
+TestCase &TestCase::operator=(const TestCase &other) noexcept { // NOLINT(cert-oop54-cpp)
+    TestCaseData::operator=(other);
+    m_test = other.m_test;
+    m_type = other.m_type;
+    m_template_id = other.m_template_id;
+    m_full_name = other.m_full_name;
+
+    if (m_template_id != -1)
+        m_name = m_full_name.c_str();
+    return *this;
+}
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+TestCase &TestCase::operator*(const char *in) noexcept {
+    m_name = in;
+    // make a new name with an appended type for templated test case
+    if (m_template_id != -1) {
+        m_full_name = String(m_name) + "<" + m_type + ">";
+        // redirect the name to point to the newly constructed full name
+        m_name = m_full_name.c_str();
+    }
+    return *this;
+}
+
+bool TestCase::operator<(const TestCase &other) const noexcept {
+    // this will be used only to differentiate between test cases - not relevant for sorting
+    if (m_line != other.m_line)
+        return m_line < other.m_line;
+    const int name_cmp = strcmp(m_name, other.m_name);
+    if (name_cmp != 0)
+        return name_cmp < 0;
+    const int file_cmp = m_file.compare(other.m_file);
+    if (file_cmp != 0)
+        return file_cmp < 0;
+    return m_template_id < other.m_template_id;
+}
+
+// used by the macros for registering tests
+int regTest(const TestCase &tc) noexcept {
+    getRegisteredTests().insert(tc);
+    return 0;
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+TestSuite &TestSuite::operator*(const char *in) noexcept {
+    m_test_suite = in;
+    return *this;
+}
+
+// sets the current test suite
+int setTestSuite(const TestSuite &ts) noexcept {
+    doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
+    return 0;
+}
+
+} // namespace detail
+} // namespace doctest
+
+namespace doctest_detail_test_suite_ns {
+// holds the current test suite
+doctest::detail::TestSuite &getCurrentTestSuite() noexcept {
+    static doctest::detail::TestSuite data{};
+    return data;
+}
+} // namespace doctest_detail_test_suite_ns
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+#ifdef DOCTEST_CONFIG_GETCURRENTTICKS
+ticks_t getCurrentTicks() {
+    return DOCTEST_CONFIG_GETCURRENTTICKS();
+}
+#elif defined(DOCTEST_PLATFORM_WINDOWS)
+ticks_t getCurrentTicks() {
+    static LARGE_INTEGER hz = {{0}}, hzo = {{0}};
+    if (!hz.QuadPart) {
+        QueryPerformanceFrequency(&hz);
+        QueryPerformanceCounter(&hzo);
+    }
+    LARGE_INTEGER t;
+    QueryPerformanceCounter(&t);
+    return ((t.QuadPart - hzo.QuadPart) * LONGLONG(1000000)) / hz.QuadPart;
+}
+#else  // DOCTEST_PLATFORM_WINDOWS
+ticks_t getCurrentTicks() {
+    timeval t;
+    gettimeofday(&t, nullptr);
+    return static_cast<ticks_t>(t.tv_sec) * 1000000 + static_cast<ticks_t>(t.tv_usec);
+}
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+void Timer::start() {
+    m_ticks = getCurrentTicks();
+}
+
+unsigned int Timer::getElapsedMicroseconds() const {
+    return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
+}
+
+// unsigned int Timer::getElapsedMilliseconds() const {
+//     return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
+// }
+
+double Timer::getElapsedSeconds() const {
+    return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0;
+}
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+
+#include <algorithm>
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+DOCTEST_NOINLINE DecisionPoint &TraversalState::ensureDecisionPointAtCurrentDepth() {
+    const size_t depth = m_decisionDepth;
+
+    if (m_discoveredDecisionPath.size() == depth) {
+        m_discoveredDecisionPath.emplace_back();
+
+        if (m_decisionPath.size() == depth)
+            m_decisionPath.push_back(0);
+    }
+
+    return m_discoveredDecisionPath[depth];
+}
+
+void TraversalState::resetForTestCase() {
+    m_decisionPath.clear();
+    m_discoveredDecisionPath.clear();
+    m_enteredSubcaseDepths.clear();
+    m_activeSubcaseDepth = 0;
+    m_decisionDepth = 0;
+}
+
+void TraversalState::resetForRun() {
+    m_activeSubcaseDepth = 0;
+    m_discoveredDecisionPath.clear();
+    m_decisionDepth = 0;
+    m_enteredSubcaseDepths.clear();
+}
+
+bool TraversalState::advance() {
+    const size_t maxDepth = std::min(m_decisionPath.size(), m_discoveredDecisionPath.size());
+    for (size_t depth = maxDepth; depth > 0; --depth) {
+        const size_t index = depth - 1;
+        if (m_decisionPath[index] + 1 < m_discoveredDecisionPath[index].branch_count) {
+            ++m_decisionPath[index];
+            m_decisionPath.resize(index + 1);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool TraversalState::tryEnterSubcase(const SubcaseSignature &signature) {
+    DecisionPoint &point = ensureDecisionPointAtCurrentDepth();
+    std::vector<SubcaseSignature> &subcases = point.subcases;
+    size_t siblingIndex = 0;
+
+    for (; siblingIndex < subcases.size(); ++siblingIndex) {
+        if (subcases[siblingIndex] == signature)
+            break;
+    }
+
+    if (siblingIndex == subcases.size())
+        subcases.push_back(signature);
+
+    point.branch_count = subcases.size();
+
+    if (siblingIndex != m_decisionPath[m_decisionDepth])
+        return false;
+
+    m_enteredSubcaseDepths.push_back(m_decisionDepth);
+    m_activeSubcaseDepth++;
+    m_decisionDepth++;
+    return true;
+}
+
+void TraversalState::leaveSubcase() {
+    m_decisionDepth = m_enteredSubcaseDepths.back();
+    m_enteredSubcaseDepths.pop_back();
+    m_activeSubcaseDepth--;
+}
+
+size_t TraversalState::unwindActiveSubcases() {
+    const size_t activeSubcaseCount = m_activeSubcaseDepth;
+
+    while (m_activeSubcaseDepth > 0)
+        leaveSubcase();
+
+    return activeSubcaseCount;
+}
+
+size_t TraversalState::acquireGeneratorIndex(size_t count) {
+    DecisionPoint &point = ensureDecisionPointAtCurrentDepth();
+    point.branch_count = count;
+
+    const size_t index = m_decisionPath[m_decisionDepth];
+    m_decisionDepth++;
+    return index < count ? index : 0;
+}
+
+size_t acquireGeneratorDecisionIndex(size_t count) {
+    return g_cs->traversal.acquireGeneratorIndex(count);
+}
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+// =================================================================================================
+// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.cpp
+// This is done so cherry-picking bug fixes is trivial - even the style/formatting is untouched.
+// =================================================================================================
+/* clang-format off */ /* NOLINTBEGIN */
+
+using uchar = unsigned char;
+
+    size_t trailingBytes(unsigned char c) {
+        if ((c & 0xE0) == 0xC0) {
+            return 2;
+        }
+        if ((c & 0xF0) == 0xE0) {
+            return 3;
+        }
+        if ((c & 0xF8) == 0xF0) {
+            return 4;
+        }
+        DOCTEST_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
+    }
+
+    uint32_t headerValue(unsigned char c) {
+        if ((c & 0xE0) == 0xC0) {
+            return c & 0x1F;
+        }
+        if ((c & 0xF0) == 0xE0) {
+            return c & 0x0F;
+        }
+        if ((c & 0xF8) == 0xF0) {
+            return c & 0x07;
+        }
+        DOCTEST_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
+    }
+
+    void hexEscapeChar(std::ostream& os, unsigned char c) {
+        std::ios_base::fmtflags f(os.flags());
+        os << "\\x"
+            << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+            << static_cast<int>(c);
+        os.flags(f);
+    }
+
+    XmlEncode::XmlEncode( std::string const& str, ForWhat forWhat )
+    :   m_str( str ),
+        m_forWhat( forWhat )
+    {}
+
+    void XmlEncode::encodeTo( std::ostream& os ) const {
+        // Apostrophe escaping not necessary if we always use " to write attributes
+        // (see: https://www.w3.org/TR/xml/#syntax)
+
+        for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
+            uchar c = m_str[idx];
+            switch (c) {
+            case '<':   os << "&lt;"; break;
+            case '&':   os << "&amp;"; break;
+
+            case '>':
+                // See: https://www.w3.org/TR/xml/#syntax
+                if (idx > 2 && m_str[idx - 1] == ']' && m_str[idx - 2] == ']')
+                    os << "&gt;";
+                else
+                    os << c;
+                break;
+
+            case '\"':
+                if (m_forWhat == ForAttributes)
+                    os << "&quot;";
+                else
+                    os << c;
+                break;
+
+            default:
+                // Check for control characters and invalid utf-8
+
+                // Escape control characters in standard ascii
+                // see https://stackoverflow.com/questions/404107/why-are-control-characters-illegal-in-xml-1-0
+                if (c < 0x09 || (c > 0x0D && c < 0x20) || c == 0x7F) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+
+                // Plain ASCII: Write it to stream
+                if (c < 0x7F) {
+                    os << c;
+                    break;
+                }
+
+                // UTF-8 territory
+                // Check if the encoding is valid and if it is not, hex escape bytes.
+                // Important: We do not check the exact decoded values for validity, only the encoding format
+                // First check that this bytes is a valid lead byte:
+                // This means that it is not encoded as 1111 1XXX
+                // Or as 10XX XXXX
+                if (c <  0xC0 ||
+                    c >= 0xF8) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+
+                auto encBytes = trailingBytes(c);
+                // Are there enough bytes left to avoid accessing out-of-bounds memory?
+                if (idx + encBytes - 1 >= m_str.size()) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+                // The header is valid, check data
+                // The next encBytes bytes must together be a valid utf-8
+                // This means: bitpattern 10XX XXXX and the extracted value is sane (ish)
+                bool valid = true;
+                uint32_t value = headerValue(c);
+                for (std::size_t n = 1; n < encBytes; ++n) {
+                    uchar nc = m_str[idx + n];
+                    valid &= ((nc & 0xC0) == 0x80);
+                    value = (value << 6) | (nc & 0x3F);
+                }
+
+                if (
+                    // Wrong bit pattern of following bytes
+                    (!valid) ||
+                    // Overlong encodings
+                    (value < 0x80) ||
+                    (                 value < 0x800   && encBytes > 2) || // removed "0x80 <= value &&" because redundant
+                    (0x800 < value && value < 0x10000 && encBytes > 3) ||
+                    // Encoded value out of range
+                    (value >= 0x110000)
+                    ) {
+                    hexEscapeChar(os, c);
+                    break;
+                }
+
+                // If we got here, this is in fact a valid(ish) utf-8 sequence
+                for (std::size_t n = 0; n < encBytes; ++n) {
+                    os << m_str[idx + n];
+                }
+                idx += encBytes - 1;
+                break;
+            }
+        }
+    }
+
+    std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode ) {
+        xmlEncode.encodeTo( os );
+        return os;
+    }
+
+    XmlWriter::ScopedElement::ScopedElement( XmlWriter* writer )
+    :   m_writer( writer )
+    {}
+
+    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) DOCTEST_NOEXCEPT
+    :   m_writer( other.m_writer ){
+        other.m_writer = nullptr;
+    }
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) DOCTEST_NOEXCEPT {
+        if ( m_writer ) {
+            m_writer->endElement();
+        }
+        m_writer = other.m_writer;
+        other.m_writer = nullptr;
+        return *this;
+    }
+
+
+    XmlWriter::ScopedElement::~ScopedElement() {
+        if( m_writer )
+            m_writer->endElement();
+    }
+
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::writeText( std::string const& text, bool indent ) {
+        m_writer->writeText( text, indent );
+        return *this;
+    }
+
+    XmlWriter::XmlWriter( std::ostream& os ) : m_os( os )
+    {
+        // writeDeclaration(); // called explicitly by the reporters that use the writer class - see issue #627
+    }
+
+    XmlWriter::~XmlWriter() {
+        while( !m_tags.empty() )
+            endElement();
+    }
+
+    XmlWriter& XmlWriter::startElement( std::string const& name ) {
+        ensureTagClosed();
+        newlineIfNecessary();
+        m_os << m_indent << '<' << name;
+        m_tags.push_back( name );
+        m_indent += "  ";
+        m_tagIsOpen = true;
+        return *this;
+    }
+
+    XmlWriter::ScopedElement XmlWriter::scopedElement( std::string const& name ) {
+        ScopedElement scoped( this );
+        startElement( name );
+        return scoped;
+    }
+
+    XmlWriter& XmlWriter::endElement() {
+        newlineIfNecessary();
+        m_indent = m_indent.substr( 0, m_indent.size()-2 );
+        if( m_tagIsOpen ) {
+            m_os << "/>";
+            m_tagIsOpen = false;
+        }
+        else {
+            m_os << m_indent << "</" << m_tags.back() << ">";
+        }
+        m_os << std::endl;
+        m_tags.pop_back();
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeAttribute( std::string const& name, std::string const& attribute ) {
+        if( !name.empty() && !attribute.empty() )
+            m_os << ' ' << name << "=\"" << XmlEncode( attribute, XmlEncode::ForAttributes ) << '"';
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeAttribute( std::string const& name, const char* attribute ) {
+        if( !name.empty() && attribute && attribute[0] != '\0' )
+            m_os << ' ' << name << "=\"" << XmlEncode( attribute, XmlEncode::ForAttributes ) << '"';
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeAttribute( std::string const& name, bool attribute ) {
+        m_os << ' ' << name << "=\"" << ( attribute ? "true" : "false" ) << '"';
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeText( std::string const& text, bool indent ) {
+        if( !text.empty() ){
+            bool tagWasOpen = m_tagIsOpen;
+            ensureTagClosed();
+            if( tagWasOpen && indent )
+                m_os << m_indent;
+            m_os << XmlEncode( text );
+            m_needsNewline = true;
+        }
+        return *this;
+    }
+
+    //XmlWriter& XmlWriter::writeComment( std::string const& text ) {
+    //    ensureTagClosed();
+    //    m_os << m_indent << "<!--" << text << "-->";
+    //    m_needsNewline = true;
+    //    return *this;
+    //}
+
+    //void XmlWriter::writeStylesheetRef( std::string const& url ) {
+    //    m_os << "<?xml-stylesheet type=\"text/xsl\" href=\"" << url << "\"?>\n";
+    //}
+
+    //XmlWriter& XmlWriter::writeBlankLine() {
+    //    ensureTagClosed();
+    //    m_os << '\n';
+    //    return *this;
+    //}
+
+    void XmlWriter::ensureTagClosed() {
+        if( m_tagIsOpen ) {
+            m_os << ">" << std::endl;
+            m_tagIsOpen = false;
+        }
+    }
+
+    void XmlWriter::writeDeclaration() {
+        m_os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    }
+
+    void XmlWriter::newlineIfNecessary() {
+        if( m_needsNewline ) {
+            m_os << std::endl;
+            m_needsNewline = false;
+        }
+    }
+
+/* clang-format on */ /* NOLINTEND */
+// =================================================================================================
+// End of copy-pasted code from Catch
+// =================================================================================================
+
+} // namespace detail
+} // namespace doctest
+
+#endif // DOCTEST_CONFIG_DISABLE
+
+DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP
+
+#endif // defined(DOCTEST_CONFIG_IMPLEMENT) && !defined(DOCTEST_LIBRARY_IMPLEMENTATION)

--- a/test/third_party/nanobench.h
+++ b/test/third_party/nanobench.h
@@ -1,0 +1,3484 @@
+//  __   _ _______ __   _  _____  ______  _______ __   _ _______ _     _
+//  | \  | |_____| | \  | |     | |_____] |______ | \  | |       |_____|
+//  |  \_| |     | |  \_| |_____| |_____] |______ |  \_| |_____  |     |
+//
+// Microbenchmark framework for C++11/14/17/20
+// https://github.com/martinus/nanobench
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019-2023 Martin Leitner-Ankerl <martin.ankerl@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ANKERL_NANOBENCH_H_INCLUDED
+#define ANKERL_NANOBENCH_H_INCLUDED
+
+// see https://semver.org/
+#define ANKERL_NANOBENCH_VERSION_MAJOR 4  // incompatible API changes
+#define ANKERL_NANOBENCH_VERSION_MINOR 3  // backwards-compatible changes
+#define ANKERL_NANOBENCH_VERSION_PATCH 11 // backwards-compatible bug fixes
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// public facing api - as minimal as possible
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <chrono>        // high_resolution_clock
+#include <cstring>       // memcpy
+#include <iosfwd>        // for std::ostream* custom output target in Config
+#include <string>        // all names
+#include <unordered_map> // holds context information of results
+#include <vector>        // holds all results
+
+#define ANKERL_NANOBENCH(x) ANKERL_NANOBENCH_PRIVATE_##x()
+
+#define ANKERL_NANOBENCH_PRIVATE_CXX() __cplusplus
+#define ANKERL_NANOBENCH_PRIVATE_CXX98() 199711L
+#define ANKERL_NANOBENCH_PRIVATE_CXX11() 201103L
+#define ANKERL_NANOBENCH_PRIVATE_CXX14() 201402L
+#define ANKERL_NANOBENCH_PRIVATE_CXX17() 201703L
+
+#if ANKERL_NANOBENCH(CXX) >= ANKERL_NANOBENCH(CXX17)
+#    define ANKERL_NANOBENCH_PRIVATE_NODISCARD() [[nodiscard]]
+#else
+#    define ANKERL_NANOBENCH_PRIVATE_NODISCARD()
+#endif
+
+#if defined(__clang__)
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_PADDED_PUSH() \
+        _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wpadded\"")
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_PADDED_POP() _Pragma("clang diagnostic pop")
+#else
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_PADDED_PUSH()
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_PADDED_POP()
+#endif
+
+#if defined(__GNUC__)
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_EFFCPP_PUSH() _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Weffc++\"")
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_EFFCPP_POP() _Pragma("GCC diagnostic pop")
+#else
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_EFFCPP_PUSH()
+#    define ANKERL_NANOBENCH_PRIVATE_IGNORE_EFFCPP_POP()
+#endif
+
+#if defined(ANKERL_NANOBENCH_LOG_ENABLED)
+#    include <iostream>
+#    define ANKERL_NANOBENCH_LOG(x)                                                 \
+        do {                                                                        \
+            std::cout << __FUNCTION__ << "@" << __LINE__ << ": " << x << std::endl; \
+        } while (0)
+#else
+#    define ANKERL_NANOBENCH_LOG(x) \
+        do {                        \
+        } while (0)
+#endif
+
+#define ANKERL_NANOBENCH_PRIVATE_PERF_COUNTERS() 0
+#if defined(__linux__) && !defined(ANKERL_NANOBENCH_DISABLE_PERF_COUNTERS)
+#    include <linux/version.h>
+#    if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 3, 0)
+// PERF_COUNT_HW_REF_CPU_CYCLES only available since kernel 3.3
+// PERF_FLAG_FD_CLOEXEC since kernel 3.14
+#        undef ANKERL_NANOBENCH_PRIVATE_PERF_COUNTERS
+#        define ANKERL_NANOBENCH_PRIVATE_PERF_COUNTERS() 1
+#    endif
+#endif
+
+#if defined(__clang__)
+#    define ANKERL_NANOBENCH_NO_SANITIZE(...) __attribute__((no_sanitize(__VA_ARGS__)))
+#else
+#    define ANKERL_NANOBENCH_NO_SANITIZE(...)
+#endif
+
+#if defined(_MSC_VER)
+#    define ANKERL_NANOBENCH_PRIVATE_NOINLINE() __declspec(noinline)
+#else
+#    define ANKERL_NANOBENCH_PRIVATE_NOINLINE() __attribute__((noinline))
+#endif
+
+// workaround missing "is_trivially_copyable" in g++ < 5.0
+// See https://stackoverflow.com/a/31798726/48181
+#if defined(__GNUC__) && __GNUC__ < 5
+#    define ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
+#else
+#    define ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
+#endif
+
+// noexcept may be missing for std::string.
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58265
+#define ANKERL_NANOBENCH_PRIVATE_NOEXCEPT_STRING_MOVE() std::is_nothrow_move_assignable<std::string>::value
+
+// declarations ///////////////////////////////////////////////////////////////////////////////////
+
+namespace ankerl {
+namespace nanobench {
+
+using Clock = std::conditional<std::chrono::high_resolution_clock::is_steady, std::chrono::high_resolution_clock,
+                               std::chrono::steady_clock>::type;
+class Bench;
+struct Config;
+class Result;
+class Rng;
+class BigO;
+
+/**
+ * @brief Renders output from a mustache-like template and benchmark results.
+ *
+ * The templating facility here is heavily inspired by [mustache - logic-less templates](https://mustache.github.io/).
+ * It adds a few more features that are necessary to get all of the captured data out of nanobench. Please read the
+ * excellent [mustache manual](https://mustache.github.io/mustache.5.html) to see what this is all about.
+ *
+ * nanobench output has two nested layers, *result* and *measurement*.  Here is a hierarchy of the allowed tags:
+ *
+ * * `{{#result}}` Marks the begin of the result layer. Whatever comes after this will be instantiated as often as
+ *   a benchmark result is available. Within it, you can use these tags:
+ *
+ *    * `{{title}}` See Bench::title.
+ *
+ *    * `{{name}}` Benchmark name, usually directly provided with Bench::run, but can also be set with Bench::name.
+ *
+ *    * `{{unit}}` Unit, e.g. `byte`. Defaults to `op`, see Bench::unit.
+ *
+ *    * `{{batch}}` Batch size, see Bench::batch.
+ *
+ *    * `{{complexityN}}` Value used for asymptotic complexity calculation. See Bench::complexityN.
+ *
+ *    * `{{epochs}}` Number of epochs, see Bench::epochs.
+ *
+ *    * `{{clockResolution}}` Accuracy of the clock, i.e. what's the smallest time possible to measure with the clock.
+ *      For modern systems, this can be around 20 ns. This value is automatically determined by nanobench at the first
+ *      benchmark that is run, and used as a static variable throughout the application's runtime.
+ *
+ *    * `{{clockResolutionMultiple}}` Configuration multiplier for `clockResolution`. See Bench::clockResolutionMultiple.
+ *      This is the target runtime for each measurement (epoch). That means the more accurate your clock is, the faster
+ *      will be the benchmark. Basing the measurement's runtime on the clock resolution is the main reason why nanobench is so fast.
+ *
+ *    * `{{maxEpochTime}}` Configuration for a maximum time each measurement (epoch) is allowed to take. Note that at least
+ *      a single iteration will be performed, even when that takes longer than maxEpochTime. See Bench::maxEpochTime.
+ *
+ *    * `{{minEpochTime}}` Minimum epoch time, defaults to 1ms. See Bench::minEpochTime.
+ *
+ *    * `{{minEpochIterations}}` See Bench::minEpochIterations.
+ *
+ *    * `{{epochIterations}}` See Bench::epochIterations.
+ *
+ *    * `{{warmup}}` Number of iterations used before measuring starts. See Bench::warmup.
+ *
+ *    * `{{relative}}` True or false, depending on the setting you have used. See Bench::relative.
+ *
+ *    * `{{context(variableName)}}` See Bench::context.
+ *
+ *    Apart from these tags, it is also possible to use some mathematical operations on the measurement data. The operations
+ *    are of the form `{{command(name)}}`.  Currently `name` can be one of `elapsed`, `iterations`. If performance counters
+ *    are available (currently only on current Linux systems), you also have `pagefaults`, `cpucycles`,
+ *    `contextswitches`, `instructions`, `branchinstructions`, and `branchmisses`. All the measures (except `iterations`) are
+ *    provided for a single iteration (so `elapsed` is the time a single iteration took). The following tags are available:
+ *
+ *    * `{{median(<name>)}}` Calculate median of a measurement data set, e.g. `{{median(elapsed)}}`.
+ *
+ *    * `{{average(<name>)}}` Average (mean) calculation.
+ *
+ *    * `{{medianAbsolutePercentError(<name>)}}` Calculates MdAPE, the Median Absolute Percentage Error. The MdAPE is an excellent
+ *      metric for the variation of measurements. It is more robust to outliers than the
+ *      [Mean absolute percentage error (M-APE)](https://en.wikipedia.org/wiki/Mean_absolute_percentage_error).
+ *      @f[
+ *       \mathrm{MdAPE}(e) = \mathrm{med}\{| \frac{e_i - \mathrm{med}\{e\}}{e_i}| \}
+ *      @f]
+ *      E.g. for *elapsed*: First, @f$ \mathrm{med}\{e\} @f$ calculates the median by sorting and then taking the middle element
+ *      of all *elapsed* measurements. This is used to calculate the absolute percentage
+ *      error to this median for each measurement, as in  @f$ | \frac{e_i - \mathrm{med}\{e\}}{e_i}| @f$. All these results
+ *      are sorted, and the middle value is chosen as the median absolute percent error.
+ *
+ *      This measurement is a bit hard to interpret, but it is very robust against outliers. E.g. a value of 5% means that half of the
+ *      measurements deviate less than 5% from the median, and the other deviate more than 5% from the median.
+ *
+ *    * `{{sum(<name>)}}` Sum of all the measurements. E.g. `{{sum(iterations)}}` will give you the total number of iterations
+*        measured in this benchmark.
+ *
+ *    * `{{minimum(<name>)}}` Minimum of all measurements.
+ *
+ *    * `{{maximum(<name>)}}` Maximum of all measurements.
+ *
+ *    * `{{sumProduct(<first>, <second>)}}` Calculates the sum of the products of corresponding measures:
+ *      @f[
+ *          \mathrm{sumProduct}(a,b) = \sum_{i=1}^{n}a_i\cdot b_i
+ *      @f]
+ *      E.g. to calculate total runtime of the benchmark, you multiply iterations with elapsed time for each measurement, and
+ *      sum these results up:
+ *      `{{sumProduct(iterations, elapsed)}}`.
+ *
+ *    * `{{#measurement}}` To access individual measurement results, open the begin tag for measurements.
+ *
+ *       * `{{elapsed}}` Average elapsed wall clock time per iteration, in seconds.
+ *
+ *       * `{{iterations}}` Number of iterations in the measurement. The number of iterations will fluctuate due
+ *         to some applied randomness, to enhance accuracy.
+ *
+ *       * `{{pagefaults}}` Average number of pagefaults per iteration.
+ *
+ *       * `{{cpucycles}}` Average number of CPU cycles processed per iteration.
+ *
+ *       * `{{contextswitches}}` Average number of context switches per iteration.
+ *
+ *       * `{{instructions}}` Average number of retired instructions per iteration.
+ *
+ *       * `{{branchinstructions}}` Average number of branches executed per iteration.
+ *
+ *       * `{{branchmisses}}` Average number of branches that were missed per iteration.
+ *
+ *    * `{{/measurement}}` Ends the measurement tag.
+ *
+ * * `{{/result}}` Marks the end of the result layer. This is the end marker for the template part that will be instantiated
+ *   for each benchmark result.
+ *
+ *
+ *  For the layer tags *result* and *measurement* you additionally can use these special markers:
+ *
+ *  * ``{{#-first}}`` - Begin marker of a template that will be instantiated *only for the first* entry in the layer. Use is only
+ *    allowed between the begin and end marker of the layer. So between ``{{#result}}`` and ``{{/result}}``, or between
+ *    ``{{#measurement}}`` and ``{{/measurement}}``. Finish the template with ``{{/-first}}``.
+ *
+ *  * ``{{^-first}}`` - Begin marker of a template that will be instantiated *for each except the first* entry in the layer. This,
+ *    this is basically the inversion of ``{{#-first}}``. Use is only allowed between the begin and end marker of the layer.
+ *    So between ``{{#result}}`` and ``{{/result}}``, or between ``{{#measurement}}`` and ``{{/measurement}}``.
+ *
+ *  * ``{{/-first}}`` - End marker for either ``{{#-first}}`` or ``{{^-first}}``.
+ *
+ *  * ``{{#-last}}`` - Begin marker of a template that will be instantiated *only for the last* entry in the layer. Use is only
+ *    allowed between the begin and end marker of the layer. So between ``{{#result}}`` and ``{{/result}}``, or between
+ *    ``{{#measurement}}`` and ``{{/measurement}}``. Finish the template with ``{{/-last}}``.
+ *
+ *  * ``{{^-last}}`` - Begin marker of a template that will be instantiated *for each except the last* entry in the layer. This,
+ *    this is basically the inversion of ``{{#-last}}``. Use is only allowed between the begin and end marker of the layer.
+ *    So between ``{{#result}}`` and ``{{/result}}``, or between ``{{#measurement}}`` and ``{{/measurement}}``.
+ *
+ *  * ``{{/-last}}`` - End marker for either ``{{#-last}}`` or ``{{^-last}}``.
+ *
+   @verbatim embed:rst
+
+   For an overview of all the possible data you can get out of nanobench, please see the tutorial at :ref:`tutorial-template-json`.
+
+   The templates that ship with nanobench are:
+
+   * :cpp:func:`templates::csv() <ankerl::nanobench::templates::csv()>`
+   * :cpp:func:`templates::json() <ankerl::nanobench::templates::json()>`
+   * :cpp:func:`templates::htmlBoxplot() <ankerl::nanobench::templates::htmlBoxplot()>`
+   * :cpp:func:`templates::pyperf() <ankerl::nanobench::templates::pyperf()>`
+
+   @endverbatim
+ *
+ * @param mustacheTemplate The template.
+ * @param bench Benchmark, containing all the results.
+ * @param out Output for the generated output.
+ */
+void render(char const* mustacheTemplate, Bench const& bench, std::ostream& out);
+void render(std::string const& mustacheTemplate, Bench const& bench, std::ostream& out);
+
+/**
+ * Same as render(char const* mustacheTemplate, Bench const& bench, std::ostream& out), but for when
+ * you only have results available.
+ *
+ * @param mustacheTemplate The template.
+ * @param results All the results to be used for rendering.
+ * @param out Output for the generated output.
+ */
+void render(char const* mustacheTemplate, std::vector<Result> const& results, std::ostream& out);
+void render(std::string const& mustacheTemplate, std::vector<Result> const& results, std::ostream& out);
+
+// Contains mustache-like templates
+namespace templates {
+
+/*!
+  @brief CSV data for the benchmark results.
+
+  Generates a comma-separated values dataset. First line is the header, each following line is a summary of each benchmark run.
+
+  @verbatim embed:rst
+  See the tutorial at :ref:`tutorial-template-csv` for an example.
+  @endverbatim
+ */
+char const* csv() noexcept;
+
+/*!
+  @brief HTML output that uses plotly to generate an interactive boxplot chart. See the tutorial for an example output.
+
+  The output uses only the elapsed wall clock time, and displays each epoch as a single dot.
+  @verbatim embed:rst
+  See the tutorial at :ref:`tutorial-template-html` for an example.
+  @endverbatim
+
+  @see also ankerl::nanobench::render()
+ */
+char const* htmlBoxplot() noexcept;
+
+/*!
+ @brief Output in pyperf compatible JSON format, which can be used for more analyzation.
+ @verbatim embed:rst
+ See the tutorial at :ref:`tutorial-template-pyperf` for an example how to further analyze the output.
+ @endverbatim
+ */
+char const* pyperf() noexcept;
+
+/*!
+  @brief Template to generate JSON data.
+
+  The generated JSON data contains *all* data that has been generated. All times are as double values, in seconds. The output can get
+  quite large.
+  @verbatim embed:rst
+  See the tutorial at :ref:`tutorial-template-json` for an example.
+  @endverbatim
+ */
+char const* json() noexcept;
+
+} // namespace templates
+
+namespace detail {
+
+template <typename T>
+struct PerfCountSet;
+
+class IterationLogic;
+class PerformanceCounters;
+
+#if ANKERL_NANOBENCH(PERF_COUNTERS)
+class LinuxPerformanceCounters;
+#endif
+
+} // namespace detail
+} // namespace nanobench
+} // namespace ankerl
+
+// definitions ////////////////////////////////////////////////////////////////////////////////////
+
+namespace ankerl {
+namespace nanobench {
+namespace detail {
+
+template <typename T>
+struct PerfCountSet {
+    T pageFaults{};
+    T cpuCycles{};
+    T contextSwitches{};
+    T instructions{};
+    T branchInstructions{};
+    T branchMisses{};
+};
+
+} // namespace detail
+
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+struct Config {
+    // actual benchmark config
+    std::string mBenchmarkTitle = "benchmark";                               // NOLINT(misc-non-private-member-variables-in-classes)
+    std::string mBenchmarkName = "noname";                                   // NOLINT(misc-non-private-member-variables-in-classes)
+    std::string mUnit = "op";                                                // NOLINT(misc-non-private-member-variables-in-classes)
+    double mBatch = 1.0;                                                     // NOLINT(misc-non-private-member-variables-in-classes)
+    double mComplexityN = -1.0;                                              // NOLINT(misc-non-private-member-variables-in-classes)
+    size_t mNumEpochs = 11;                                                  // NOLINT(misc-non-private-member-variables-in-classes)
+    size_t mClockResolutionMultiple = static_cast<size_t>(1000);             // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mMaxEpochTime = std::chrono::milliseconds(100); // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mMinEpochTime = std::chrono::milliseconds(1);   // NOLINT(misc-non-private-member-variables-in-classes)
+    uint64_t mMinEpochIterations{1};                                         // NOLINT(misc-non-private-member-variables-in-classes)
+    // If not 0, run *exactly* these number of iterations per epoch.
+    uint64_t mEpochIterations{0};                                          // NOLINT(misc-non-private-member-variables-in-classes)
+    uint64_t mWarmup = 0;                                                  // NOLINT(misc-non-private-member-variables-in-classes)
+    std::ostream* mOut = nullptr;                                          // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::duration<double> mTimeUnit = std::chrono::nanoseconds{1}; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::string mTimeUnitName = "ns";                                      // NOLINT(misc-non-private-member-variables-in-classes)
+    bool mShowPerformanceCounters = true;                                  // NOLINT(misc-non-private-member-variables-in-classes)
+    bool mIsRelative = false;                                              // NOLINT(misc-non-private-member-variables-in-classes)
+    std::unordered_map<std::string, std::string> mContext{};               // NOLINT(misc-non-private-member-variables-in-classes)
+
+    Config();
+    ~Config();
+    Config& operator=(Config const& other);
+    Config& operator=(Config&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
+    Config(Config const& other);
+    Config(Config&& other) noexcept;
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+// Result returned after a benchmark has finished. Can be used as a baseline for relative().
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+class Result {
+public:
+    enum class Measure : size_t {
+        elapsed,
+        iterations,
+        pagefaults,
+        cpucycles,
+        contextswitches,
+        instructions,
+        branchinstructions,
+        branchmisses,
+        _size
+    };
+
+    explicit Result(Config benchmarkConfig);
+
+    ~Result();
+    Result& operator=(Result const& other);
+    Result& operator=(Result&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
+    Result(Result const& other);
+    Result(Result&& other) noexcept;
+
+    // adds new measurement results
+    // all values are scaled by iters (except iters...)
+    void add(Clock::duration totalElapsed, uint64_t iters, detail::PerformanceCounters const& pc);
+
+    ANKERL_NANOBENCH(NODISCARD) Config const& config() const noexcept;
+
+    ANKERL_NANOBENCH(NODISCARD) double median(Measure m) const;
+    ANKERL_NANOBENCH(NODISCARD) double medianAbsolutePercentError(Measure m) const;
+    ANKERL_NANOBENCH(NODISCARD) double average(Measure m) const;
+    ANKERL_NANOBENCH(NODISCARD) double sum(Measure m) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double sumProduct(Measure m1, Measure m2) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double minimum(Measure m) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double maximum(Measure m) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::string const& context(char const* variableName) const;
+    ANKERL_NANOBENCH(NODISCARD) std::string const& context(std::string const& variableName) const;
+
+    ANKERL_NANOBENCH(NODISCARD) bool has(Measure m) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double get(size_t idx, Measure m) const;
+    ANKERL_NANOBENCH(NODISCARD) bool empty() const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) size_t size() const noexcept;
+
+    // Finds string, if not found, returns _size.
+    static Measure fromString(std::string const& str);
+
+private:
+    Config mConfig{};
+    std::vector<std::vector<double>> mNameToMeasurements{};
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+/**
+ * An extremely fast random generator. Currently, this implements *RomuDuoJr*, developed by Mark Overton. Source:
+ * http://www.romu-random.org/
+ *
+ * RomuDuoJr is extremely fast and provides reasonable good randomness. Not enough for large jobs, but definitely
+ * good enough for a benchmarking framework.
+ *
+ *  * Estimated capacity: @f$ 2^{51} @f$ bytes
+ *  * Register pressure: 4
+ *  * State size: 128 bits
+ *
+ * This random generator is a drop-in replacement for the generators supplied by ``<random>``. It is not
+ * cryptographically secure. It's intended purpose is to be very fast so that benchmarks that make use
+ * of randomness are not distorted too much by the random generator.
+ *
+ * Rng also provides a few non-standard helpers, optimized for speed.
+ */
+class Rng final {
+public:
+    /**
+     * @brief This RNG provides 64bit randomness.
+     */
+    using result_type = uint64_t;
+
+    static constexpr uint64_t(min)();
+    static constexpr uint64_t(max)();
+
+    /**
+     * As a safety precaution, we don't allow copying. Copying a PRNG would mean you would have two random generators that produce the
+     * same sequence, which is generally not what one wants. Instead create a new rng with the default constructor Rng(), which is
+     * automatically seeded from `std::random_device`. If you really need a copy, use `copy()`.
+     */
+    Rng(Rng const&) = delete;
+
+    /**
+     * Same as Rng(Rng const&), we don't allow assignment. If you need a new Rng create one with the default constructor Rng().
+     */
+    Rng& operator=(Rng const&) = delete;
+
+    // moving is ok
+    Rng(Rng&&) noexcept = default;
+    Rng& operator=(Rng&&) noexcept = default;
+    ~Rng() noexcept = default;
+
+    /**
+     * @brief Creates a new Random generator with random seed.
+     *
+     * Instead of a default seed (as the random generators from the STD), this properly seeds the random generator from
+     * `std::random_device`. It guarantees correct seeding. Note that seeding can be relatively slow, depending on the source of
+     * randomness used. So it is best to create a Rng once and use it for all your randomness purposes.
+     */
+    Rng();
+
+    /*!
+      Creates a new Rng that is seeded with a specific seed. Each Rng created from the same seed will produce the same randomness
+      sequence. This can be useful for deterministic behavior.
+
+      @verbatim embed:rst
+      .. note::
+
+         The random algorithm might change between nanobench releases. Whenever a faster and/or better random
+         generator becomes available, I will switch the implementation.
+      @endverbatim
+
+      As per the Romu paper, this seeds the Rng with splitMix64 algorithm and performs 10 initial rounds for further mixing up of the
+      internal state.
+
+      @param seed  The 64bit seed. All values are allowed, even 0.
+     */
+    explicit Rng(uint64_t seed) noexcept;
+    Rng(uint64_t x, uint64_t y) noexcept;
+    explicit Rng(std::vector<uint64_t> const& data);
+
+    /**
+     * Creates a copy of the Rng, thus the copy provides exactly the same random sequence as the original.
+     */
+    ANKERL_NANOBENCH(NODISCARD) Rng copy() const noexcept;
+
+    /**
+     * @brief Produces a 64bit random value. This should be very fast, thus it is marked as inline. In my benchmark, this is ~46 times
+     * faster than `std::default_random_engine` for producing 64bit random values. It seems that the fastest std contender is
+     * `std::mt19937_64`. Still, this RNG is 2-3 times as fast.
+     *
+     * @return uint64_t The next 64 bit random value.
+     */
+    inline uint64_t operator()() noexcept;
+
+    // This is slightly biased. See
+
+    /**
+     * Generates a random number between 0 and range (excluding range).
+     *
+     * The algorithm only produces 32bit numbers, and is slightly biased. The effect is quite small unless your range is close to the
+     * maximum value of an integer. It is possible to correct the bias with rejection sampling (see
+     * [here](https://lemire.me/blog/2016/06/30/fast-random-shuffling/), but this is most likely irrelevant in practices for the
+     * purposes of this Rng.
+     *
+     * See Daniel Lemire's blog post [A fast alternative to the modulo
+     * reduction](https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/)
+     *
+     * @param range Upper exclusive range. E.g a value of 3 will generate random numbers 0, 1, 2.
+     * @return uint32_t Generated random values in range [0, range(.
+     */
+    inline uint32_t bounded(uint32_t range) noexcept;
+
+    // random double in range [0, 1(
+    // see http://prng.di.unimi.it/
+
+    /**
+     * Provides a random uniform double value between 0 and 1. This uses the method described in [Generating uniform doubles in the
+     * unit interval](http://prng.di.unimi.it/), and is extremely fast.
+     *
+     * @return double Uniformly distributed double value in range [0,1(, excluding 1.
+     */
+    inline double uniform01() noexcept;
+
+    /**
+     * Shuffles all entries in the given container. Although this has a slight bias due to the implementation of bounded(), this is
+     * preferable to `std::shuffle` because it is over 5 times faster. See Daniel Lemire's blog post [Fast random
+     * shuffling](https://lemire.me/blog/2016/06/30/fast-random-shuffling/).
+     *
+     * @param container The whole container will be shuffled.
+     */
+    template <typename Container>
+    void shuffle(Container& container) noexcept;
+
+    /**
+     * Extracts the full state of the generator, e.g. for serialization. For this RNG this is just 2 values, but to stay API compatible
+     * with future implementations that potentially use more state, we use a vector.
+     *
+     * @return Vector containing the full state:
+     */
+    ANKERL_NANOBENCH(NODISCARD) std::vector<uint64_t> state() const;
+
+private:
+    static constexpr uint64_t rotl(uint64_t x, unsigned k) noexcept;
+
+    uint64_t mX;
+    uint64_t mY;
+};
+
+/**
+ * @brief Main entry point to nanobench's benchmarking facility.
+ *
+ * It holds configuration and results from one or more benchmark runs. Usually it is used in a single line, where the object is
+ * constructed, configured, and then a benchmark is run. E.g. like this:
+ *
+ *     ankerl::nanobench::Bench().unit("byte").batch(1000).run("random fluctuations", [&] {
+ *         // here be the benchmark code
+ *     });
+ *
+ * In that example Bench() constructs the benchmark, it is then configured with unit() and batch(), and after configuration a
+ * benchmark is executed with run(). Once run() has finished, it prints the result to `std::cout`. It would also store the results
+ * in the Bench instance, but in this case the object is immediately destroyed so it's not available any more.
+ */
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+class Bench {
+public:
+    /**
+     * @brief Creates a new benchmark for configuration and running of benchmarks.
+     */
+    Bench();
+
+    Bench(Bench&& other) noexcept;
+    Bench& operator=(Bench&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
+    Bench(Bench const& other);
+    Bench& operator=(Bench const& other);
+    ~Bench() noexcept;
+
+    /*!
+      @brief Repeatedly calls `op()` based on the configuration, and performs measurements.
+
+      This call is marked with `noinline` to prevent the compiler to optimize beyond different benchmarks. This can have quite a big
+      effect on benchmark accuracy.
+
+      @verbatim embed:rst
+      .. note::
+
+        Each call to your lambda must have a side effect that the compiler can't possibly optimize it away. E.g. add a result to an
+        externally defined number (like `x` in the above example), and finally call `doNotOptimizeAway` on the variables the compiler
+        must not remove. You can also use :cpp:func:`ankerl::nanobench::doNotOptimizeAway` directly in the lambda, but be aware that
+        this has a small overhead.
+
+      @endverbatim
+
+      @tparam Op The code to benchmark.
+     */
+    template <typename Op>
+    ANKERL_NANOBENCH(NOINLINE)
+    Bench& run(char const* benchmarkName, Op&& op);
+
+    template <typename Op>
+    ANKERL_NANOBENCH(NOINLINE)
+    Bench& run(std::string const& benchmarkName, Op&& op);
+
+    /**
+     * @brief Same as run(char const* benchmarkName, Op op), but instead uses the previously set name.
+     * @tparam Op The code to benchmark.
+     */
+    template <typename Op>
+    ANKERL_NANOBENCH(NOINLINE)
+    Bench& run(Op&& op);
+
+    /**
+     * @brief Title of the benchmark, will be shown in the table header. Changing the title will start a new markdown table.
+     *
+     * @param benchmarkTitle The title of the benchmark.
+     */
+    Bench& title(char const* benchmarkTitle);
+    Bench& title(std::string const& benchmarkTitle);
+
+    /**
+     * @brief Gets the title of the benchmark
+     */
+    ANKERL_NANOBENCH(NODISCARD) std::string const& title() const noexcept;
+
+    /// Name of the benchmark, will be shown in the table row.
+    Bench& name(char const* benchmarkName);
+    Bench& name(std::string const& benchmarkName);
+    ANKERL_NANOBENCH(NODISCARD) std::string const& name() const noexcept;
+
+    /**
+     * @brief Set context information.
+     *
+     * The information can be accessed using custom render templates via `{{context(variableName)}}`.
+     * Trying to render a variable that hasn't been set before raises an exception.
+     * Not included in (default) markdown table.
+     *
+     * @see clearContext, render
+     *
+     * @param variableName The name of the context variable.
+     * @param variableValue The value of the context variable.
+     */
+    Bench& context(char const* variableName, char const* variableValue);
+    Bench& context(std::string const& variableName, std::string const& variableValue);
+
+    /**
+     * @brief Reset context information.
+     *
+     * This may improve efficiency when using many context entries,
+     * or improve robustness by removing spurious context entries.
+     *
+     * @see context
+     */
+    Bench& clearContext();
+
+    /**
+     * @brief Sets the batch size.
+     *
+     * E.g. number of processed byte, or some other metric for the size of the processed data in each iteration. If you benchmark
+     * hashing of a 1000 byte long string and want byte/sec as a result, you can specify 1000 as the batch size.
+     *
+     * @tparam T Any input type is internally cast to `double`.
+     * @param b batch size
+     */
+    template <typename T>
+    Bench& batch(T b) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double batch() const noexcept;
+
+    /**
+     * @brief Sets the operation unit.
+     *
+     * Defaults to "op". Could be e.g. "byte" for string processing. This is used for the table header, e.g. to show `ns/byte`. Use
+     * singular (*byte*, not *bytes*). A change clears the currently collected results.
+     *
+     * @param unit The unit name.
+     */
+    Bench& unit(char const* unit);
+    Bench& unit(std::string const& unit);
+    ANKERL_NANOBENCH(NODISCARD) std::string const& unit() const noexcept;
+
+    /**
+     * @brief Sets the time unit to be used for the default output.
+     *
+     * Nanobench defaults to using ns (nanoseconds) as output in the markdown. For some benchmarks this is too coarse, so it is
+     * possible to configure this. E.g. use `timeUnit(1ms, "ms")` to show `ms/op` instead of `ns/op`.
+     *
+     * @param tu Time unit to display the results in, default is 1ns.
+     * @param tuName Name for the time unit, default is "ns"
+     */
+    Bench& timeUnit(std::chrono::duration<double> const& tu, std::string const& tuName);
+    ANKERL_NANOBENCH(NODISCARD) std::string const& timeUnitName() const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::chrono::duration<double> const& timeUnit() const noexcept;
+
+    /**
+     * @brief Set the output stream where the resulting markdown table will be printed to.
+     *
+     * The default is `&std::cout`. You can disable all output by setting `nullptr`.
+     *
+     * @param outstream Pointer to output stream, can be `nullptr`.
+     */
+    Bench& output(std::ostream* outstream) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::ostream* output() const noexcept;
+
+    /**
+     * Modern processors have a very accurate clock, being able to measure as low as 20 nanoseconds. This is the main trick nanobech to
+     * be so fast: we find out how accurate the clock is, then run the benchmark only so often that the clock's accuracy is good enough
+     * for accurate measurements.
+     *
+     * The default is to run one epoch for 1000 times the clock resolution. So for 20ns resolution and 11 epochs, this gives a total
+     * runtime of
+     *
+     * @f[
+     * 20ns * 1000 * 11 \approx 0.2ms
+     * @f]
+     *
+     * To be precise, nanobench adds a 0-20% random noise to each evaluation. This is to prevent any aliasing effects, and further
+     * improves accuracy.
+     *
+     * Total runtime will be higher though: Some initial time is needed to find out the target number of iterations for each epoch, and
+     * there is some overhead involved to start & stop timers and calculate resulting statistics and writing the output.
+     *
+     * @param multiple Target number of times of clock resolution. Usually 1000 is a good compromise between runtime and accuracy.
+     */
+    Bench& clockResolutionMultiple(size_t multiple) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) size_t clockResolutionMultiple() const noexcept;
+
+    /**
+     * @brief Controls number of epochs, the number of measurements to perform.
+     *
+     * The reported result will be the median of evaluation of each epoch. The higher you choose this, the more
+     * deterministic the result be and outliers will be more easily removed. Also the `err%` will be more accurate the higher this
+     * number is. Note that the `err%` will not necessarily decrease when number of epochs is increased. But it will be a more accurate
+     * representation of the benchmarked code's runtime stability.
+     *
+     * Choose the value wisely. In practice, 11 has been shown to be a reasonable choice between runtime performance and accuracy.
+     * This setting goes hand in hand with minEpochIterations() (or minEpochTime()). If you are more interested in *median* runtime,
+     * you might want to increase epochs(). If you are more interested in *mean* runtime, you might want to increase
+     * minEpochIterations() instead.
+     *
+     * @param numEpochs Number of epochs.
+     */
+    Bench& epochs(size_t numEpochs) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) size_t epochs() const noexcept;
+
+    /**
+     * @brief Upper limit for the runtime of each epoch.
+     *
+     * As a safety precaution if the clock is not very accurate, we can set an upper limit for the maximum evaluation time per
+     * epoch. Default is 100ms. At least a single evaluation of the benchmark is performed.
+     *
+     * @see minEpochTime, minEpochIterations
+     *
+     * @param t Maximum target runtime for a single epoch.
+     */
+    Bench& maxEpochTime(std::chrono::nanoseconds t) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::chrono::nanoseconds maxEpochTime() const noexcept;
+
+    /**
+     * @brief Minimum time each epoch should take.
+     *
+     * Default is 1ms, so we are mostly relying on clockResolutionMultiple(). In most cases this is exactly what you want. If you see
+     * that the evaluation is unreliable with a high `err%`, you can increase either minEpochTime() or minEpochIterations().
+     *
+     * @see maxEpochTime, minEpochIterations
+     *
+     * @param t Minimum time each epoch should take.
+     */
+    Bench& minEpochTime(std::chrono::nanoseconds t) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::chrono::nanoseconds minEpochTime() const noexcept;
+
+    /**
+     * @brief Sets the minimum number of iterations each epoch should take.
+     *
+     * Default is 1, and we rely on clockResolutionMultiple(). If the `err%` is high and you want a more smooth result, you might want
+     * to increase the minimum number of iterations, or increase the minEpochTime().
+     *
+     * @see minEpochTime, maxEpochTime, minEpochIterations
+     *
+     * @param numIters Minimum number of iterations per epoch.
+     */
+    Bench& minEpochIterations(uint64_t numIters) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) uint64_t minEpochIterations() const noexcept;
+
+    /**
+     * Sets exactly the number of iterations for each epoch. Ignores all other epoch limits. This forces nanobench to use exactly
+     * the given number of iterations for each epoch, not more and not less. Default is 0 (disabled).
+     *
+     * @param numIters Exact number of iterations to use. Set to 0 to disable.
+     */
+    Bench& epochIterations(uint64_t numIters) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) uint64_t epochIterations() const noexcept;
+
+    /**
+     * @brief Sets a number of iterations that are initially performed without any measurements.
+     *
+     * Some benchmarks need a few evaluations to warm up caches / database / whatever access. Normally this should not be needed, since
+     * we show the median result so initial outliers will be filtered away automatically. If the warmup effect is large though, you
+     * might want to set it. Default is 0.
+     *
+     * @param numWarmupIters Number of warmup iterations.
+     */
+    Bench& warmup(uint64_t numWarmupIters) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) uint64_t warmup() const noexcept;
+
+    /**
+     * @brief Marks the next run as the baseline.
+     *
+     * Call `relative(true)` to mark the run as the baseline. Successive runs will be compared to this run. It is calculated by
+     *
+     * @f[
+     * 100\% * \frac{baseline}{runtime}
+     * @f]
+     *
+     *  * 100% means it is exactly as fast as the baseline
+     *  * >100% means it is faster than the baseline. E.g. 200% means the current run is twice as fast as the baseline.
+     *  * <100% means it is slower than the baseline. E.g. 50% means it is twice as slow as the baseline.
+     *
+     * See the tutorial section "Comparing Results" for example usage.
+     *
+     * @param isRelativeEnabled True to enable processing
+     */
+    Bench& relative(bool isRelativeEnabled) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) bool relative() const noexcept;
+
+    /**
+     * @brief Enables/disables performance counters.
+     *
+     * On Linux nanobench has a powerful feature to use performance counters. This enables counting of retired instructions, count
+     * number of branches, missed branches, etc. On default this is enabled, but you can disable it if you don't need that feature.
+     *
+     * @param showPerformanceCounters True to enable, false to disable.
+     */
+    Bench& performanceCounters(bool showPerformanceCounters) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) bool performanceCounters() const noexcept;
+
+    /**
+     * @brief Retrieves all benchmark results collected by the bench object so far.
+     *
+     * Each call to run() generates a Result that is stored within the Bench instance. This is mostly for advanced users who want to
+     * see all the nitty gritty details.
+     *
+     * @return All results collected so far.
+     */
+    ANKERL_NANOBENCH(NODISCARD) std::vector<Result> const& results() const noexcept;
+
+    /*!
+      @verbatim embed:rst
+
+      Convenience shortcut to :cpp:func:`ankerl::nanobench::doNotOptimizeAway`.
+
+      @endverbatim
+     */
+    template <typename Arg>
+    Bench& doNotOptimizeAway(Arg&& arg);
+
+    /*!
+      @verbatim embed:rst
+
+      Sets N for asymptotic complexity calculation, so it becomes possible to calculate `Big O
+      <https://en.wikipedia.org/wiki/Big_O_notation>`_ from multiple benchmark evaluations.
+
+      Use :cpp:func:`ankerl::nanobench::Bench::complexityBigO` when the evaluation has finished. See the tutorial
+      :ref:`asymptotic-complexity` for details.
+
+      @endverbatim
+
+      @tparam T Any type is cast to `double`.
+      @param n Length of N for the next benchmark run, so it is possible to calculate `bigO`.
+     */
+    template <typename T>
+    Bench& complexityN(T n) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double complexityN() const noexcept;
+
+    /*!
+      Calculates [Big O](https://en.wikipedia.org/wiki/Big_O_notation>) of the results with all preconfigured complexity functions.
+      Currently these complexity functions are fitted into the benchmark results:
+
+       @f$ \mathcal{O}(1) @f$,
+       @f$ \mathcal{O}(n) @f$,
+       @f$ \mathcal{O}(\log{}n) @f$,
+       @f$ \mathcal{O}(n\log{}n) @f$,
+       @f$ \mathcal{O}(n^2) @f$,
+       @f$ \mathcal{O}(n^3) @f$.
+
+      If we e.g. evaluate the complexity of `std::sort`, this is the result of `std::cout << bench.complexityBigO()`:
+
+      ```
+      |   coefficient |   err% | complexity
+      |--------------:|-------:|------------
+      |   5.08935e-09 |   2.6% | O(n log n)
+      |   6.10608e-08 |   8.0% | O(n)
+      |   1.29307e-11 |  47.2% | O(n^2)
+      |   2.48677e-15 |  69.6% | O(n^3)
+      |   9.88133e-06 | 132.3% | O(log n)
+      |   5.98793e-05 | 162.5% | O(1)
+      ```
+
+      So in this case @f$ \mathcal{O}(n\log{}n) @f$ provides the best approximation.
+
+      @verbatim embed:rst
+      See the tutorial :ref:`asymptotic-complexity` for details.
+      @endverbatim
+      @return Evaluation results, which can be printed or otherwise inspected.
+     */
+    std::vector<BigO> complexityBigO() const;
+
+    /**
+     * @brief Calculates bigO for a custom function.
+     *
+     * E.g. to calculate the mean squared error for @f$ \mathcal{O}(\log{}\log{}n) @f$, which is not part of the default set of
+     * complexityBigO(), you can do this:
+     *
+     * ```
+     * auto logLogN = bench.complexityBigO("O(log log n)", [](double n) {
+     *     return std::log2(std::log2(n));
+     * });
+     * ```
+     *
+     * The resulting mean squared error can be printed with `std::cout << logLogN`. E.g. it prints something like this:
+     *
+     * ```text
+     * 2.46985e-05 * O(log log n), rms=1.48121
+     * ```
+     *
+     * @tparam Op Type of mapping operation.
+     * @param name Name for the function, e.g. "O(log log n)"
+     * @param op Op's operator() maps a `double` with the desired complexity function, e.g. `log2(log2(n))`.
+     * @return BigO Error calculation, which is streamable to std::cout.
+     */
+    template <typename Op>
+    BigO complexityBigO(char const* name, Op op) const;
+
+    template <typename Op>
+    BigO complexityBigO(std::string const& name, Op op) const;
+
+    /*!
+      @verbatim embed:rst
+
+      Convenience shortcut to :cpp:func:`ankerl::nanobench::render`.
+
+      @endverbatim
+     */
+    Bench& render(char const* templateContent, std::ostream& os);
+    Bench& render(std::string const& templateContent, std::ostream& os);
+
+    Bench& config(Config const& benchmarkConfig);
+    ANKERL_NANOBENCH(NODISCARD) Config const& config() const noexcept;
+
+private:
+    Config mConfig{};
+    std::vector<Result> mResults{};
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+/**
+ * @brief Makes sure none of the given arguments are optimized away by the compiler.
+ *
+ * @tparam Arg Type of the argument that shouldn't be optimized away.
+ * @param arg The input that we mark as being used, even though we don't do anything with it.
+ */
+template <typename Arg>
+void doNotOptimizeAway(Arg&& arg);
+
+namespace detail {
+
+#if defined(_MSC_VER)
+void doNotOptimizeAwaySink(void const*);
+
+template <typename T>
+void doNotOptimizeAway(T const& val);
+
+#else
+
+// These assembly magic is directly from what Google Benchmark is doing. I have previously used what facebook's folly was doing, but
+// this seemed to have compilation problems in some cases. Google Benchmark seemed to be the most well tested anyways.
+// see https://github.com/google/benchmark/blob/v1.7.1/include/benchmark/benchmark.h#L443-L446
+template <typename T>
+void doNotOptimizeAway(T const& val) {
+    // NOLINTNEXTLINE(hicpp-no-assembler)
+    asm volatile("" : : "r,m"(val) : "memory");
+}
+
+template <typename T>
+void doNotOptimizeAway(T& val) {
+#    if defined(__clang__)
+    // NOLINTNEXTLINE(hicpp-no-assembler)
+    asm volatile("" : "+r,m"(val) : : "memory");
+#    else
+    // NOLINTNEXTLINE(hicpp-no-assembler)
+    asm volatile("" : "+m,r"(val) : : "memory");
+#    endif
+}
+#endif
+
+// internally used, but visible because run() is templated.
+// Not movable/copy-able, so we simply use a pointer instead of unique_ptr. This saves us from
+// having to include <memory>, and the template instantiation overhead of unique_ptr which is unfortunately quite significant.
+ANKERL_NANOBENCH(IGNORE_EFFCPP_PUSH)
+class IterationLogic {
+public:
+    explicit IterationLogic(Bench const& bench);
+    IterationLogic(IterationLogic&&) = delete;
+    IterationLogic& operator=(IterationLogic&&) = delete;
+    IterationLogic(IterationLogic const&) = delete;
+    IterationLogic& operator=(IterationLogic const&) = delete;
+    ~IterationLogic();
+
+    ANKERL_NANOBENCH(NODISCARD) uint64_t numIters() const noexcept;
+    void add(std::chrono::nanoseconds elapsed, PerformanceCounters const& pc) noexcept;
+    void moveResultTo(std::vector<Result>& results) noexcept;
+
+private:
+    struct Impl;
+    Impl* mPimpl;
+};
+ANKERL_NANOBENCH(IGNORE_EFFCPP_POP)
+
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+class PerformanceCounters {
+public:
+    PerformanceCounters(PerformanceCounters const&) = delete;
+    PerformanceCounters(PerformanceCounters&&) = delete;
+    PerformanceCounters& operator=(PerformanceCounters const&) = delete;
+    PerformanceCounters& operator=(PerformanceCounters&&) = delete;
+
+    PerformanceCounters();
+    ~PerformanceCounters();
+
+    void beginMeasure();
+    void endMeasure();
+    void updateResults(uint64_t numIters);
+
+    ANKERL_NANOBENCH(NODISCARD) PerfCountSet<uint64_t> const& val() const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) PerfCountSet<bool> const& has() const noexcept;
+
+private:
+#if ANKERL_NANOBENCH(PERF_COUNTERS)
+    LinuxPerformanceCounters* mPc = nullptr;
+#endif
+    PerfCountSet<uint64_t> mVal{};
+    PerfCountSet<bool> mHas{};
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+// Gets the singleton
+PerformanceCounters& performanceCounters();
+
+} // namespace detail
+
+class BigO {
+public:
+    using RangeMeasure = std::vector<std::pair<double, double>>;
+
+    template <typename Op>
+    static RangeMeasure mapRangeMeasure(RangeMeasure data, Op op) {
+        for (auto& rangeMeasure : data) {
+            rangeMeasure.first = op(rangeMeasure.first);
+        }
+        return data;
+    }
+
+    static RangeMeasure collectRangeMeasure(std::vector<Result> const& results);
+
+    template <typename Op>
+    BigO(char const* bigOName, RangeMeasure const& rangeMeasure, Op rangeToN)
+        : BigO(bigOName, mapRangeMeasure(rangeMeasure, rangeToN)) {}
+
+    template <typename Op>
+    BigO(std::string bigOName, RangeMeasure const& rangeMeasure, Op rangeToN)
+        : BigO(std::move(bigOName), mapRangeMeasure(rangeMeasure, rangeToN)) {}
+
+    BigO(char const* bigOName, RangeMeasure const& scaledRangeMeasure);
+    BigO(std::string bigOName, RangeMeasure const& scaledRangeMeasure);
+    ANKERL_NANOBENCH(NODISCARD) std::string const& name() const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double constant() const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) double normalizedRootMeanSquare() const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) bool operator<(BigO const& other) const noexcept;
+
+private:
+    std::string mName{};
+    double mConstant{};
+    double mNormalizedRootMeanSquare{};
+};
+std::ostream& operator<<(std::ostream& os, BigO const& bigO);
+std::ostream& operator<<(std::ostream& os, std::vector<ankerl::nanobench::BigO> const& bigOs);
+
+} // namespace nanobench
+} // namespace ankerl
+
+// implementation /////////////////////////////////////////////////////////////////////////////////
+
+namespace ankerl {
+namespace nanobench {
+
+constexpr uint64_t(Rng::min)() {
+    return 0;
+}
+
+constexpr uint64_t(Rng::max)() {
+    return (std::numeric_limits<uint64_t>::max)();
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+uint64_t Rng::operator()() noexcept {
+    auto x = mX;
+
+    mX = UINT64_C(15241094284759029579) * mY;
+    mY = rotl(mY - x, 27);
+
+    return x;
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+uint32_t Rng::bounded(uint32_t range) noexcept {
+    uint64_t const r32 = static_cast<uint32_t>(operator()());
+    auto multiresult = r32 * range;
+    return static_cast<uint32_t>(multiresult >> 32U);
+}
+
+double Rng::uniform01() noexcept {
+    auto i = (UINT64_C(0x3ff) << 52U) | (operator()() >> 12U);
+    // can't use union in c++ here for type puning, it's undefined behavior.
+    // std::memcpy is optimized anyways.
+    double d{};
+    std::memcpy(&d, &i, sizeof(double));
+    return d - 1.0;
+}
+
+template <typename Container>
+void Rng::shuffle(Container& container) noexcept {
+    auto i = container.size();
+    while (i > 1U) {
+        using std::swap;
+        auto n = operator()();
+        // using decltype(i) instead of size_t to be compatible to containers with 32bit index (see #80)
+        auto b1 = static_cast<decltype(i)>((static_cast<uint32_t>(n) * static_cast<uint64_t>(i)) >> 32U);
+        swap(container[--i], container[b1]);
+
+        auto b2 = static_cast<decltype(i)>(((n >> 32U) * static_cast<uint64_t>(i)) >> 32U);
+        swap(container[--i], container[b2]);
+    }
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+constexpr uint64_t Rng::rotl(uint64_t x, unsigned k) noexcept {
+    return (x << k) | (x >> (64U - k));
+}
+
+template <typename Op>
+ANKERL_NANOBENCH_NO_SANITIZE("integer")
+Bench& Bench::run(Op&& op) {
+    // It is important that this method is kept short so the compiler can do better optimizations/ inlining of op()
+    detail::IterationLogic iterationLogic(*this);
+    auto& pc = detail::performanceCounters();
+
+    while (auto n = iterationLogic.numIters()) {
+        pc.beginMeasure();
+        Clock::time_point const before = Clock::now();
+        while (n-- > 0) {
+            op();
+        }
+        Clock::time_point const after = Clock::now();
+        pc.endMeasure();
+        pc.updateResults(iterationLogic.numIters());
+        iterationLogic.add(after - before, pc);
+    }
+    iterationLogic.moveResultTo(mResults);
+    return *this;
+}
+
+// Performs all evaluations.
+template <typename Op>
+Bench& Bench::run(char const* benchmarkName, Op&& op) {
+    name(benchmarkName);
+    return run(std::forward<Op>(op));
+}
+
+template <typename Op>
+Bench& Bench::run(std::string const& benchmarkName, Op&& op) {
+    name(benchmarkName);
+    return run(std::forward<Op>(op));
+}
+
+template <typename Op>
+BigO Bench::complexityBigO(char const* benchmarkName, Op op) const {
+    return BigO(benchmarkName, BigO::collectRangeMeasure(mResults), op);
+}
+
+template <typename Op>
+BigO Bench::complexityBigO(std::string const& benchmarkName, Op op) const {
+    return BigO(benchmarkName, BigO::collectRangeMeasure(mResults), op);
+}
+
+// Set the batch size, e.g. number of processed bytes, or some other metric for the size of the processed data in each iteration.
+// Any argument is cast to double.
+template <typename T>
+Bench& Bench::batch(T b) noexcept {
+    mConfig.mBatch = static_cast<double>(b);
+    return *this;
+}
+
+// Sets the computation complexity of the next run. Any argument is cast to double.
+template <typename T>
+Bench& Bench::complexityN(T n) noexcept {
+    mConfig.mComplexityN = static_cast<double>(n);
+    return *this;
+}
+
+// Convenience: makes sure none of the given arguments are optimized away by the compiler.
+template <typename Arg>
+Bench& Bench::doNotOptimizeAway(Arg&& arg) {
+    detail::doNotOptimizeAway(std::forward<Arg>(arg));
+    return *this;
+}
+
+// Makes sure none of the given arguments are optimized away by the compiler.
+template <typename Arg>
+void doNotOptimizeAway(Arg&& arg) {
+    detail::doNotOptimizeAway(std::forward<Arg>(arg));
+}
+
+namespace detail {
+
+#if defined(_MSC_VER)
+template <typename T>
+void doNotOptimizeAway(T const& val) {
+    doNotOptimizeAwaySink(&val);
+}
+
+#endif
+
+} // namespace detail
+} // namespace nanobench
+} // namespace ankerl
+
+#if defined(ANKERL_NANOBENCH_IMPLEMENT)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// implementation part - only visible in .cpp
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+#    include <algorithm> // sort, reverse
+#    include <atomic>    // compare_exchange_strong in loop overhead
+#    include <cstdlib>   // getenv
+#    include <cstring>   // strstr, strncmp
+#    include <fstream>   // ifstream to parse proc files
+#    include <iomanip>   // setw, setprecision
+#    include <iostream>  // cout
+#    include <numeric>   // accumulate
+#    include <random>    // random_device
+#    include <sstream>   // to_s in Number
+#    include <stdexcept> // throw for rendering templates
+#    include <tuple>     // std::tie
+#    if defined(__linux__)
+#        include <unistd.h> //sysconf
+#    endif
+#    if ANKERL_NANOBENCH(PERF_COUNTERS)
+#        include <map> // map
+
+#        include <linux/perf_event.h>
+#        include <sys/ioctl.h>
+#        include <sys/syscall.h>
+#    endif
+
+// declarations ///////////////////////////////////////////////////////////////////////////////////
+
+namespace ankerl {
+namespace nanobench {
+
+// helper stuff that is only intended to be used internally
+namespace detail {
+
+struct TableInfo;
+
+// formatting utilities
+namespace fmt {
+
+class NumSep;
+class StreamStateRestorer;
+class Number;
+class MarkDownColumn;
+class MarkDownCode;
+
+} // namespace fmt
+} // namespace detail
+} // namespace nanobench
+} // namespace ankerl
+
+// definitions ////////////////////////////////////////////////////////////////////////////////////
+
+namespace ankerl {
+namespace nanobench {
+
+uint64_t splitMix64(uint64_t& state) noexcept;
+
+namespace detail {
+
+// helpers to get double values
+template <typename T>
+inline double d(T t) noexcept {
+    return static_cast<double>(t);
+}
+inline double d(Clock::duration duration) noexcept {
+    return std::chrono::duration_cast<std::chrono::duration<double>>(duration).count();
+}
+
+// Calculates clock resolution once, and remembers the result
+inline Clock::duration clockResolution() noexcept;
+
+} // namespace detail
+
+namespace templates {
+
+char const* csv() noexcept {
+    return R"DELIM("title";"name";"unit";"batch";"elapsed";"error %";"instructions";"branches";"branch misses";"total"
+{{#result}}"{{title}}";"{{name}}";"{{unit}}";{{batch}};{{median(elapsed)}};{{medianAbsolutePercentError(elapsed)}};{{median(instructions)}};{{median(branchinstructions)}};{{median(branchmisses)}};{{sumProduct(iterations, elapsed)}}
+{{/result}})DELIM";
+}
+
+char const* htmlBoxplot() noexcept {
+    return R"DELIM(<html>
+
+<head>
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+
+<body>
+    <div id="myDiv"></div>
+    <script>
+        var data = [
+            {{#result}}{
+                name: '{{name}}',
+                y: [{{#measurement}}{{elapsed}}{{^-last}}, {{/last}}{{/measurement}}],
+            },
+            {{/result}}
+        ];
+        var title = '{{title}}';
+
+        data = data.map(a => Object.assign(a, { boxpoints: 'all', pointpos: 0, type: 'box' }));
+        var layout = { title: { text: title }, showlegend: false, yaxis: { title: 'time per unit', rangemode: 'tozero', autorange: true } }; Plotly.newPlot('myDiv', data, layout, {responsive: true});
+    </script>
+</body>
+
+</html>)DELIM";
+}
+
+char const* pyperf() noexcept {
+    return R"DELIM({
+    "benchmarks": [
+        {
+            "runs": [
+                {
+                    "values": [
+{{#measurement}}                        {{elapsed}}{{^-last}},
+{{/last}}{{/measurement}}
+                    ]
+                }
+            ]
+        }
+    ],
+    "metadata": {
+        "loops": {{sum(iterations)}},
+        "inner_loops": {{batch}},
+        "name": "{{title}}",
+        "unit": "second"
+    },
+    "version": "1.0"
+})DELIM";
+}
+
+char const* json() noexcept {
+    return R"DELIM({
+    "results": [
+{{#result}}        {
+            "title": "{{title}}",
+            "name": "{{name}}",
+            "unit": "{{unit}}",
+            "batch": {{batch}},
+            "complexityN": {{complexityN}},
+            "epochs": {{epochs}},
+            "clockResolution": {{clockResolution}},
+            "clockResolutionMultiple": {{clockResolutionMultiple}},
+            "maxEpochTime": {{maxEpochTime}},
+            "minEpochTime": {{minEpochTime}},
+            "minEpochIterations": {{minEpochIterations}},
+            "epochIterations": {{epochIterations}},
+            "warmup": {{warmup}},
+            "relative": {{relative}},
+            "median(elapsed)": {{median(elapsed)}},
+            "medianAbsolutePercentError(elapsed)": {{medianAbsolutePercentError(elapsed)}},
+            "median(instructions)": {{median(instructions)}},
+            "medianAbsolutePercentError(instructions)": {{medianAbsolutePercentError(instructions)}},
+            "median(cpucycles)": {{median(cpucycles)}},
+            "median(contextswitches)": {{median(contextswitches)}},
+            "median(pagefaults)": {{median(pagefaults)}},
+            "median(branchinstructions)": {{median(branchinstructions)}},
+            "median(branchmisses)": {{median(branchmisses)}},
+            "totalTime": {{sumProduct(iterations, elapsed)}},
+            "measurements": [
+{{#measurement}}                {
+                    "iterations": {{iterations}},
+                    "elapsed": {{elapsed}},
+                    "pagefaults": {{pagefaults}},
+                    "cpucycles": {{cpucycles}},
+                    "contextswitches": {{contextswitches}},
+                    "instructions": {{instructions}},
+                    "branchinstructions": {{branchinstructions}},
+                    "branchmisses": {{branchmisses}}
+                }{{^-last}},{{/-last}}
+{{/measurement}}            ]
+        }{{^-last}},{{/-last}}
+{{/result}}    ]
+})DELIM";
+}
+
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+struct Node {
+    enum class Type { tag, content, section, inverted_section };
+
+    char const* begin;
+    char const* end;
+    std::vector<Node> children;
+    Type type;
+
+    template <size_t N>
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    bool operator==(char const (&str)[N]) const noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        return static_cast<size_t>(std::distance(begin, end) + 1) == N && 0 == strncmp(str, begin, N - 1);
+    }
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+// NOLINTNEXTLINE(misc-no-recursion)
+static std::vector<Node> parseMustacheTemplate(char const** tpl) {
+    std::vector<Node> nodes;
+
+    while (true) {
+        auto const* begin = std::strstr(*tpl, "{{");
+        auto const* end = begin;
+        if (begin != nullptr) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            begin += 2;
+            end = std::strstr(begin, "}}");
+        }
+
+        if (begin == nullptr || end == nullptr) {
+            // nothing found, finish node
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            nodes.emplace_back(Node{*tpl, *tpl + std::strlen(*tpl), std::vector<Node>{}, Node::Type::content});
+            return nodes;
+        }
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        nodes.emplace_back(Node{*tpl, begin - 2, std::vector<Node>{}, Node::Type::content});
+
+        // we found a tag
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        *tpl = end + 2;
+        switch (*begin) {
+        case '/':
+            // finished! bail out
+            return nodes;
+
+        case '#':
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            nodes.emplace_back(Node{begin + 1, end, parseMustacheTemplate(tpl), Node::Type::section});
+            break;
+
+        case '^':
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            nodes.emplace_back(Node{begin + 1, end, parseMustacheTemplate(tpl), Node::Type::inverted_section});
+            break;
+
+        default:
+            nodes.emplace_back(Node{begin, end, std::vector<Node>{}, Node::Type::tag});
+            break;
+        }
+    }
+}
+
+static bool generateFirstLast(Node const& n, size_t idx, size_t size, std::ostream& out) {
+    ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
+    bool const matchFirst = n == "-first";
+    bool const matchLast = n == "-last";
+    if (!matchFirst && !matchLast) {
+        return false;
+    }
+
+    bool doWrite = false;
+    if (n.type == Node::Type::section) {
+        doWrite = (matchFirst && idx == 0) || (matchLast && idx == size - 1);
+    } else if (n.type == Node::Type::inverted_section) {
+        doWrite = (matchFirst && idx != 0) || (matchLast && idx != size - 1);
+    }
+
+    if (doWrite) {
+        for (auto const& child : n.children) {
+            if (child.type == Node::Type::content) {
+                out.write(child.begin, std::distance(child.begin, child.end));
+            }
+        }
+    }
+    return true;
+}
+
+static bool matchCmdArgs(std::string const& str, std::vector<std::string>& matchResult) {
+    matchResult.clear();
+    auto idxOpen = str.find('(');
+    auto idxClose = str.find(')', idxOpen);
+    if (idxClose == std::string::npos) {
+        return false;
+    }
+
+    matchResult.emplace_back(str.substr(0, idxOpen));
+
+    // split by comma
+    matchResult.emplace_back();
+    for (size_t i = idxOpen + 1; i != idxClose; ++i) {
+        if (str[i] == ' ' || str[i] == '\t') {
+            // skip whitespace
+            continue;
+        }
+        if (str[i] == ',') {
+            // got a comma => new string
+            matchResult.emplace_back();
+            continue;
+        }
+        // no whitespace no comma, append
+        matchResult.back() += str[i];
+    }
+    return true;
+}
+
+static bool generateConfigTag(Node const& n, Config const& config, std::ostream& out) {
+    using detail::d;
+
+    if (n == "title") {
+        out << config.mBenchmarkTitle;
+        return true;
+    }
+    if (n == "name") {
+        out << config.mBenchmarkName;
+        return true;
+    }
+    if (n == "unit") {
+        out << config.mUnit;
+        return true;
+    }
+    if (n == "batch") {
+        out << config.mBatch;
+        return true;
+    }
+    if (n == "complexityN") {
+        out << config.mComplexityN;
+        return true;
+    }
+    if (n == "epochs") {
+        out << config.mNumEpochs;
+        return true;
+    }
+    if (n == "clockResolution") {
+        out << d(detail::clockResolution());
+        return true;
+    }
+    if (n == "clockResolutionMultiple") {
+        out << config.mClockResolutionMultiple;
+        return true;
+    }
+    if (n == "maxEpochTime") {
+        out << d(config.mMaxEpochTime);
+        return true;
+    }
+    if (n == "minEpochTime") {
+        out << d(config.mMinEpochTime);
+        return true;
+    }
+    if (n == "minEpochIterations") {
+        out << config.mMinEpochIterations;
+        return true;
+    }
+    if (n == "epochIterations") {
+        out << config.mEpochIterations;
+        return true;
+    }
+    if (n == "warmup") {
+        out << config.mWarmup;
+        return true;
+    }
+    if (n == "relative") {
+        out << config.mIsRelative;
+        return true;
+    }
+    return false;
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static std::ostream& generateResultTag(Node const& n, Result const& r, std::ostream& out) {
+    if (generateConfigTag(n, r.config(), out)) {
+        return out;
+    }
+    // match e.g. "median(elapsed)"
+    // g++ 4.8 doesn't implement std::regex :(
+    // static std::regex const regOpArg1("^([a-zA-Z]+)\\(([a-zA-Z]*)\\)$");
+    // std::cmatch matchResult;
+    // if (std::regex_match(n.begin, n.end, matchResult, regOpArg1)) {
+    std::vector<std::string> matchResult;
+    if (matchCmdArgs(std::string(n.begin, n.end), matchResult)) {
+        if (matchResult.size() == 2) {
+            if (matchResult[0] == "context") {
+                return out << r.context(matchResult[1]);
+            }
+
+            auto m = Result::fromString(matchResult[1]);
+            if (m == Result::Measure::_size) {
+                return out << 0.0;
+            }
+
+            if (matchResult[0] == "median") {
+                return out << r.median(m);
+            }
+            if (matchResult[0] == "average") {
+                return out << r.average(m);
+            }
+            if (matchResult[0] == "medianAbsolutePercentError") {
+                return out << r.medianAbsolutePercentError(m);
+            }
+            if (matchResult[0] == "sum") {
+                return out << r.sum(m);
+            }
+            if (matchResult[0] == "minimum") {
+                return out << r.minimum(m);
+            }
+            if (matchResult[0] == "maximum") {
+                return out << r.maximum(m);
+            }
+        } else if (matchResult.size() == 3) {
+            auto m1 = Result::fromString(matchResult[1]);
+            auto m2 = Result::fromString(matchResult[2]);
+            if (m1 == Result::Measure::_size || m2 == Result::Measure::_size) {
+                return out << 0.0;
+            }
+
+            if (matchResult[0] == "sumProduct") {
+                return out << r.sumProduct(m1, m2);
+            }
+        }
+    }
+
+    // match e.g. "sumProduct(elapsed, iterations)"
+    // static std::regex const regOpArg2("^([a-zA-Z]+)\\(([a-zA-Z]*)\\s*,\\s+([a-zA-Z]*)\\)$");
+
+    // nothing matches :(
+    throw std::runtime_error("command '" + std::string(n.begin, n.end) + "' not understood");
+}
+
+static void generateResultMeasurement(std::vector<Node> const& nodes, size_t idx, Result const& r, std::ostream& out) {
+    for (auto const& n : nodes) {
+        if (!generateFirstLast(n, idx, r.size(), out)) {
+            ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
+            switch (n.type) {
+            case Node::Type::content:
+                out.write(n.begin, std::distance(n.begin, n.end));
+                break;
+
+            case Node::Type::inverted_section:
+                throw std::runtime_error("got a inverted section inside measurement");
+
+            case Node::Type::section:
+                throw std::runtime_error("got a section inside measurement");
+
+            case Node::Type::tag: {
+                auto m = Result::fromString(std::string(n.begin, n.end));
+                if (m == Result::Measure::_size || !r.has(m)) {
+                    out << 0.0;
+                } else {
+                    out << r.get(idx, m);
+                }
+                break;
+            }
+            }
+        }
+    }
+}
+
+static void generateResult(std::vector<Node> const& nodes, size_t idx, std::vector<Result> const& results, std::ostream& out) {
+    auto const& r = results[idx];
+    for (auto const& n : nodes) {
+        if (!generateFirstLast(n, idx, results.size(), out)) {
+            ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
+            switch (n.type) {
+            case Node::Type::content:
+                out.write(n.begin, std::distance(n.begin, n.end));
+                break;
+
+            case Node::Type::inverted_section:
+                throw std::runtime_error("got a inverted section inside result");
+
+            case Node::Type::section:
+                if (n == "measurement") {
+                    for (size_t i = 0; i < r.size(); ++i) {
+                        generateResultMeasurement(n.children, i, r, out);
+                    }
+                } else {
+                    throw std::runtime_error("got a section inside result");
+                }
+                break;
+
+            case Node::Type::tag:
+                generateResultTag(n, r, out);
+                break;
+            }
+        }
+    }
+}
+
+} // namespace templates
+
+// helper stuff that only intended to be used internally
+namespace detail {
+
+char const* getEnv(char const* name);
+bool isEndlessRunning(std::string const& name);
+bool isWarningsEnabled();
+
+template <typename T>
+T parseFile(std::string const& filename, bool* fail);
+
+void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<std::string>& recommendations);
+void printStabilityInformationOnce(std::ostream* outStream);
+
+// remembers the last table settings used. When it changes, a new table header is automatically written for the new entry.
+uint64_t& singletonHeaderHash() noexcept;
+
+// determines resolution of the given clock. This is done by measuring multiple times and returning the minimum time difference.
+Clock::duration calcClockResolution(size_t numEvaluations) noexcept;
+
+// formatting utilities
+namespace fmt {
+
+// adds thousands separator to numbers
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+class NumSep : public std::numpunct<char> {
+public:
+    explicit NumSep(char sep);
+    char do_thousands_sep() const override;
+    std::string do_grouping() const override;
+
+private:
+    char mSep;
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+// RAII to save & restore a stream's state
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+class StreamStateRestorer {
+public:
+    explicit StreamStateRestorer(std::ostream& s);
+    ~StreamStateRestorer();
+
+    // sets back all stream info that we remembered at construction
+    void restore();
+
+    // don't allow copying / moving
+    StreamStateRestorer(StreamStateRestorer const&) = delete;
+    StreamStateRestorer& operator=(StreamStateRestorer const&) = delete;
+    StreamStateRestorer(StreamStateRestorer&&) = delete;
+    StreamStateRestorer& operator=(StreamStateRestorer&&) = delete;
+
+private:
+    std::ostream& mStream;
+    std::locale mLocale;
+    std::streamsize const mPrecision;
+    std::streamsize const mWidth;
+    std::ostream::char_type const mFill;
+    std::ostream::fmtflags const mFmtFlags;
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+// Number formatter
+class Number {
+public:
+    Number(int width, int precision, double value);
+    Number(int width, int precision, int64_t value);
+    ANKERL_NANOBENCH(NODISCARD) std::string to_s() const;
+
+private:
+    friend std::ostream& operator<<(std::ostream& os, Number const& n);
+    std::ostream& write(std::ostream& os) const;
+
+    int mWidth;
+    int mPrecision;
+    double mValue;
+};
+
+// helper replacement for std::to_string of signed/unsigned numbers so we are locale independent
+std::string to_s(uint64_t n);
+
+std::ostream& operator<<(std::ostream& os, Number const& n);
+
+class MarkDownColumn {
+public:
+    MarkDownColumn(int w, int prec, std::string tit, std::string suff, double val) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::string title() const;
+    ANKERL_NANOBENCH(NODISCARD) std::string separator() const;
+    ANKERL_NANOBENCH(NODISCARD) std::string invalid() const;
+    ANKERL_NANOBENCH(NODISCARD) std::string value() const;
+
+private:
+    int mWidth;
+    int mPrecision;
+    std::string mTitle;
+    std::string mSuffix;
+    double mValue;
+};
+
+// Formats any text as markdown code, escaping backticks.
+class MarkDownCode {
+public:
+    explicit MarkDownCode(std::string const& what);
+
+private:
+    friend std::ostream& operator<<(std::ostream& os, MarkDownCode const& mdCode);
+    std::ostream& write(std::ostream& os) const;
+
+    std::string mWhat{};
+};
+
+std::ostream& operator<<(std::ostream& os, MarkDownCode const& mdCode);
+
+} // namespace fmt
+} // namespace detail
+} // namespace nanobench
+} // namespace ankerl
+
+// implementation /////////////////////////////////////////////////////////////////////////////////
+
+namespace ankerl {
+namespace nanobench {
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void render(char const* mustacheTemplate, std::vector<Result> const& results, std::ostream& out) {
+    detail::fmt::StreamStateRestorer const restorer(out);
+
+    out.precision(std::numeric_limits<double>::digits10);
+    auto nodes = templates::parseMustacheTemplate(&mustacheTemplate);
+
+    for (auto const& n : nodes) {
+        ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
+        switch (n.type) {
+        case templates::Node::Type::content:
+            out.write(n.begin, std::distance(n.begin, n.end));
+            break;
+
+        case templates::Node::Type::inverted_section:
+            throw std::runtime_error("unknown list '" + std::string(n.begin, n.end) + "'");
+
+        case templates::Node::Type::section:
+            if (n == "result") {
+                const size_t nbResults = results.size();
+                for (size_t i = 0; i < nbResults; ++i) {
+                    generateResult(n.children, i, results, out);
+                }
+            } else if (n == "measurement") {
+                if (results.size() != 1) {
+                    throw std::runtime_error(
+                        "render: can only use section 'measurement' here if there is a single result, but there are " +
+                        detail::fmt::to_s(results.size()));
+                }
+                // when we only have a single result, we can immediately go into its measurement.
+                auto const& r = results.front();
+                for (size_t i = 0; i < r.size(); ++i) {
+                    generateResultMeasurement(n.children, i, r, out);
+                }
+            } else {
+                throw std::runtime_error("render: unknown section '" + std::string(n.begin, n.end) + "'");
+            }
+            break;
+
+        case templates::Node::Type::tag:
+            if (results.size() == 1) {
+                // result & config are both supported there
+                generateResultTag(n, results.front(), out);
+            } else {
+                // This just uses the last result's config.
+                if (!generateConfigTag(n, results.back().config(), out)) {
+                    throw std::runtime_error("unknown tag '" + std::string(n.begin, n.end) + "'");
+                }
+            }
+            break;
+        }
+    }
+}
+
+void render(std::string const& mustacheTemplate, std::vector<Result> const& results, std::ostream& out) {
+    render(mustacheTemplate.c_str(), results, out);
+}
+
+void render(char const* mustacheTemplate, const Bench& bench, std::ostream& out) {
+    render(mustacheTemplate, bench.results(), out);
+}
+
+void render(std::string const& mustacheTemplate, const Bench& bench, std::ostream& out) {
+    render(mustacheTemplate.c_str(), bench.results(), out);
+}
+
+namespace detail {
+
+PerformanceCounters& performanceCounters() {
+#    if defined(__clang__)
+#        pragma clang diagnostic push
+#        pragma clang diagnostic ignored "-Wexit-time-destructors"
+#    endif
+    static PerformanceCounters pc;
+#    if defined(__clang__)
+#        pragma clang diagnostic pop
+#    endif
+    return pc;
+}
+
+// Windows version of doNotOptimizeAway
+// see https://github.com/google/benchmark/blob/v1.7.1/include/benchmark/benchmark.h#L514
+// see https://github.com/facebook/folly/blob/v2023.01.30.00/folly/lang/Hint-inl.h#L54-L58
+// see https://learn.microsoft.com/en-us/cpp/preprocessor/optimize
+#    if defined(_MSC_VER)
+#        pragma optimize("", off)
+void doNotOptimizeAwaySink(void const*) {}
+#        pragma optimize("", on)
+#    endif
+
+template <typename T>
+T parseFile(std::string const& filename, bool* fail) {
+    std::ifstream fin(filename); // NOLINT(misc-const-correctness)
+    T num{};
+    fin >> num;
+    if (fail != nullptr) {
+        *fail = fin.fail();
+    }
+    return num;
+}
+
+char const* getEnv(char const* name) {
+#    if defined(_MSC_VER)
+#        pragma warning(push)
+#        pragma warning(disable : 4996) // getenv': This function or variable may be unsafe.
+#    endif
+    return std::getenv(name); // NOLINT(concurrency-mt-unsafe)
+#    if defined(_MSC_VER)
+#        pragma warning(pop)
+#    endif
+}
+
+bool isEndlessRunning(std::string const& name) {
+    auto const* const endless = getEnv("NANOBENCH_ENDLESS");
+    return nullptr != endless && endless == name;
+}
+
+// True when environment variable NANOBENCH_SUPPRESS_WARNINGS is either not set at all, or set to "0"
+bool isWarningsEnabled() {
+    auto const* const suppression = getEnv("NANOBENCH_SUPPRESS_WARNINGS");
+    return nullptr == suppression || suppression == std::string("0");
+}
+
+void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<std::string>& recommendations) {
+    warnings.clear();
+    recommendations.clear();
+
+#    if defined(DEBUG)
+    warnings.emplace_back("DEBUG defined");
+    bool const recommendCheckFlags = true;
+#    else
+    bool const recommendCheckFlags = false;
+#    endif
+
+    bool recommendPyPerf = false;
+#    if defined(__linux__)
+    auto nprocs = sysconf(_SC_NPROCESSORS_CONF);
+    if (nprocs <= 0) {
+        warnings.emplace_back("couldn't figure out number of processors - no governor, turbo check possible");
+    } else {
+        // check frequency scaling
+        for (long id = 0; id < nprocs; ++id) {
+            auto idStr = detail::fmt::to_s(static_cast<uint64_t>(id));
+            auto sysCpu = "/sys/devices/system/cpu/cpu" + idStr;
+            auto minFreq = parseFile<int64_t>(sysCpu + "/cpufreq/scaling_min_freq", nullptr);
+            auto maxFreq = parseFile<int64_t>(sysCpu + "/cpufreq/scaling_max_freq", nullptr);
+            if (minFreq != maxFreq) {
+                auto minMHz = d(minFreq) / 1000.0;
+                auto maxMHz = d(maxFreq) / 1000.0;
+                warnings.emplace_back("CPU frequency scaling enabled: CPU " + idStr + " between " +
+                                      detail::fmt::Number(1, 1, minMHz).to_s() + " and " + detail::fmt::Number(1, 1, maxMHz).to_s() +
+                                      " MHz");
+                recommendPyPerf = true;
+                break;
+            }
+        }
+
+        auto fail = false;
+        auto currentGovernor = parseFile<std::string>("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor", &fail);
+        if (!fail && "performance" != currentGovernor) {
+            warnings.emplace_back("CPU governor is '" + currentGovernor + "' but should be 'performance'");
+            recommendPyPerf = true;
+        }
+
+        auto noTurbo = parseFile<int>("/sys/devices/system/cpu/intel_pstate/no_turbo", &fail);
+        if (!fail && noTurbo == 0) {
+            warnings.emplace_back("Turbo is enabled, CPU frequency will fluctuate");
+            recommendPyPerf = true;
+        }
+    }
+#    endif
+
+    if (recommendCheckFlags) {
+        recommendations.emplace_back("Make sure you compile for Release");
+    }
+    if (recommendPyPerf) {
+        recommendations.emplace_back("Use 'pyperf system tune' before benchmarking. See https://github.com/psf/pyperf");
+    }
+}
+
+void printStabilityInformationOnce(std::ostream* outStream) {
+    static bool shouldPrint = true;
+    if (shouldPrint && (nullptr != outStream) && isWarningsEnabled()) {
+        auto& os = *outStream;
+        shouldPrint = false;
+        std::vector<std::string> warnings;
+        std::vector<std::string> recommendations;
+        gatherStabilityInformation(warnings, recommendations);
+        if (warnings.empty()) {
+            return;
+        }
+
+        os << "Warning, results might be unstable:" << std::endl;
+        for (auto const& w : warnings) {
+            os << "* " << w << std::endl;
+        }
+
+        os << std::endl << "Recommendations" << std::endl;
+        for (auto const& r : recommendations) {
+            os << "* " << r << std::endl;
+        }
+    }
+}
+
+// remembers the last table settings used. When it changes, a new table header is automatically written for the new entry.
+uint64_t& singletonHeaderHash() noexcept {
+    static uint64_t sHeaderHash{};
+    return sHeaderHash;
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+inline uint64_t hash_combine(uint64_t seed, uint64_t val) {
+    return seed ^ (val + UINT64_C(0x9e3779b9) + (seed << 6U) + (seed >> 2U));
+}
+
+// determines resolution of the given clock. This is done by measuring multiple times and returning the minimum time difference.
+Clock::duration calcClockResolution(size_t numEvaluations) noexcept {
+    auto bestDuration = Clock::duration::max();
+    Clock::time_point tBegin;
+    Clock::time_point tEnd;
+    for (size_t i = 0; i < numEvaluations; ++i) {
+        tBegin = Clock::now();
+        do {
+            tEnd = Clock::now();
+        } while (tBegin == tEnd);
+        bestDuration = (std::min)(bestDuration, tEnd - tBegin);
+    }
+    return bestDuration;
+}
+
+// Calculates clock resolution once, and remembers the result
+Clock::duration clockResolution() noexcept {
+    static Clock::duration const sResolution = calcClockResolution(20);
+    return sResolution;
+}
+
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+struct IterationLogic::Impl {
+    enum class State { warmup, upscaling_runtime, measuring, endless };
+
+    explicit Impl(Bench const& bench)
+        : mBench(bench)
+        , mResult(bench.config()) {
+        printStabilityInformationOnce(mBench.output());
+
+        // determine target runtime per epoch
+        mTargetRuntimePerEpoch = detail::clockResolution() * mBench.clockResolutionMultiple();
+        if (mTargetRuntimePerEpoch > mBench.maxEpochTime()) {
+            mTargetRuntimePerEpoch = mBench.maxEpochTime();
+        }
+        if (mTargetRuntimePerEpoch < mBench.minEpochTime()) {
+            mTargetRuntimePerEpoch = mBench.minEpochTime();
+        }
+
+        if (isEndlessRunning(mBench.name())) {
+            std::cerr << "NANOBENCH_ENDLESS set: running '" << mBench.name() << "' endlessly" << std::endl;
+            mNumIters = (std::numeric_limits<uint64_t>::max)();
+            mState = State::endless;
+        } else if (0 != mBench.warmup()) {
+            mNumIters = mBench.warmup();
+            mState = State::warmup;
+        } else if (0 != mBench.epochIterations()) {
+            // exact number of iterations
+            mNumIters = mBench.epochIterations();
+            mState = State::measuring;
+        } else {
+            mNumIters = mBench.minEpochIterations();
+            mState = State::upscaling_runtime;
+        }
+    }
+
+    // directly calculates new iters based on elapsed&iters, and adds a 10% noise. Makes sure we don't underflow.
+    ANKERL_NANOBENCH(NODISCARD) uint64_t calcBestNumIters(std::chrono::nanoseconds elapsed, uint64_t iters) noexcept {
+        auto doubleElapsed = d(elapsed);
+        auto doubleTargetRuntimePerEpoch = d(mTargetRuntimePerEpoch);
+        auto doubleNewIters = doubleTargetRuntimePerEpoch / doubleElapsed * d(iters);
+
+        auto doubleMinEpochIters = d(mBench.minEpochIterations());
+        if (doubleNewIters < doubleMinEpochIters) {
+            doubleNewIters = doubleMinEpochIters;
+        }
+        doubleNewIters *= 1.0 + 0.2 * mRng.uniform01();
+
+        // +0.5 for correct rounding when casting
+        // NOLINTNEXTLINE(bugprone-incorrect-roundings)
+        return static_cast<uint64_t>(doubleNewIters + 0.5);
+    }
+
+    ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined") void upscale(std::chrono::nanoseconds elapsed) {
+        if (elapsed * 10 < mTargetRuntimePerEpoch) {
+            // we are far below the target runtime. Multiply iterations by 10 (with overflow check)
+            if (mNumIters * 10 < mNumIters) {
+                // overflow :-(
+                showResult("iterations overflow. Maybe your code got optimized away?");
+                mNumIters = 0;
+                return;
+            }
+            mNumIters *= 10;
+        } else {
+            mNumIters = calcBestNumIters(elapsed, mNumIters);
+        }
+    }
+
+    void add(std::chrono::nanoseconds elapsed, PerformanceCounters const& pc) noexcept {
+#    if defined(ANKERL_NANOBENCH_LOG_ENABLED)
+        auto oldIters = mNumIters;
+#    endif
+
+        switch (mState) {
+        case State::warmup:
+            if (isCloseEnoughForMeasurements(elapsed)) {
+                // if elapsed is close enough, we can skip upscaling and go right to measurements
+                // still, we don't add the result to the measurements.
+                mState = State::measuring;
+                mNumIters = calcBestNumIters(elapsed, mNumIters);
+            } else {
+                // not close enough: switch to upscaling
+                mState = State::upscaling_runtime;
+                upscale(elapsed);
+            }
+            break;
+
+        case State::upscaling_runtime:
+            if (isCloseEnoughForMeasurements(elapsed)) {
+                // if we are close enough, add measurement and switch to always measuring
+                mState = State::measuring;
+                mTotalElapsed += elapsed;
+                mTotalNumIters += mNumIters;
+                mResult.add(elapsed, mNumIters, pc);
+                mNumIters = calcBestNumIters(mTotalElapsed, mTotalNumIters);
+            } else {
+                upscale(elapsed);
+            }
+            break;
+
+        case State::measuring:
+            // just add measurements - no questions asked. Even when runtime is low. But we can't ignore
+            // that fluctuation, or else we would bias the result
+            mTotalElapsed += elapsed;
+            mTotalNumIters += mNumIters;
+            mResult.add(elapsed, mNumIters, pc);
+            if (0 != mBench.epochIterations()) {
+                mNumIters = mBench.epochIterations();
+            } else {
+                mNumIters = calcBestNumIters(mTotalElapsed, mTotalNumIters);
+            }
+            break;
+
+        case State::endless:
+            mNumIters = (std::numeric_limits<uint64_t>::max)();
+            break;
+        }
+
+        if (static_cast<uint64_t>(mResult.size()) == mBench.epochs()) {
+            // we got all the results that we need, finish it
+            showResult("");
+            mNumIters = 0;
+        }
+
+        ANKERL_NANOBENCH_LOG(mBench.name() << ": " << detail::fmt::Number(20, 3, d(elapsed.count())) << " elapsed, "
+                                           << detail::fmt::Number(20, 3, d(mTargetRuntimePerEpoch.count())) << " target. oldIters="
+                                           << oldIters << ", mNumIters=" << mNumIters << ", mState=" << static_cast<int>(mState));
+    }
+
+    // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+    void showResult(std::string const& errorMessage) const {
+        ANKERL_NANOBENCH_LOG(errorMessage);
+
+        if (mBench.output() != nullptr) {
+            // prepare column data ///////
+            std::vector<fmt::MarkDownColumn> columns;
+
+            auto rMedian = mResult.median(Result::Measure::elapsed);
+
+            if (mBench.relative()) {
+                double d = 100.0;
+                if (!mBench.results().empty()) {
+                    d = rMedian <= 0.0 ? 0.0 : mBench.results().front().median(Result::Measure::elapsed) / rMedian * 100.0;
+                }
+                columns.emplace_back(11, 1, "relative", "%", d);
+            }
+
+            if (mBench.complexityN() > 0) {
+                columns.emplace_back(14, 0, "complexityN", "", mBench.complexityN());
+            }
+
+            columns.emplace_back(22, 2, mBench.timeUnitName() + "/" + mBench.unit(), "",
+                                 rMedian / (mBench.timeUnit().count() * mBench.batch()));
+            columns.emplace_back(22, 2, mBench.unit() + "/s", "", rMedian <= 0.0 ? 0.0 : mBench.batch() / rMedian);
+
+            double const rErrorMedian = mResult.medianAbsolutePercentError(Result::Measure::elapsed);
+            columns.emplace_back(10, 1, "err%", "%", rErrorMedian * 100.0);
+
+            double rInsMedian = -1.0;
+            if (mBench.performanceCounters() && mResult.has(Result::Measure::instructions)) {
+                rInsMedian = mResult.median(Result::Measure::instructions);
+                columns.emplace_back(18, 2, "ins/" + mBench.unit(), "", rInsMedian / mBench.batch());
+            }
+
+            double rCycMedian = -1.0;
+            if (mBench.performanceCounters() && mResult.has(Result::Measure::cpucycles)) {
+                rCycMedian = mResult.median(Result::Measure::cpucycles);
+                columns.emplace_back(18, 2, "cyc/" + mBench.unit(), "", rCycMedian / mBench.batch());
+            }
+            if (rInsMedian > 0.0 && rCycMedian > 0.0) {
+                columns.emplace_back(9, 3, "IPC", "", rCycMedian <= 0.0 ? 0.0 : rInsMedian / rCycMedian);
+            }
+            if (mBench.performanceCounters() && mResult.has(Result::Measure::branchinstructions)) {
+                double const rBraMedian = mResult.median(Result::Measure::branchinstructions);
+                columns.emplace_back(17, 2, "bra/" + mBench.unit(), "", rBraMedian / mBench.batch());
+                if (mResult.has(Result::Measure::branchmisses)) {
+                    double p = 0.0;
+                    if (rBraMedian >= 1e-9) {
+                        p = 100.0 * mResult.median(Result::Measure::branchmisses) / rBraMedian;
+                    }
+                    columns.emplace_back(10, 1, "miss%", "%", p);
+                }
+            }
+
+            columns.emplace_back(12, 2, "total", "", mResult.sumProduct(Result::Measure::iterations, Result::Measure::elapsed));
+
+            // write everything
+            auto& os = *mBench.output();
+
+            // combine all elements that are relevant for printing the header
+            uint64_t hash = 0;
+            hash = hash_combine(std::hash<std::string>{}(mBench.unit()), hash);
+            hash = hash_combine(std::hash<std::string>{}(mBench.title()), hash);
+            hash = hash_combine(std::hash<std::string>{}(mBench.timeUnitName()), hash);
+            hash = hash_combine(std::hash<double>{}(mBench.timeUnit().count()), hash);
+            hash = hash_combine(std::hash<bool>{}(mBench.relative()), hash);
+            hash = hash_combine(std::hash<bool>{}(mBench.performanceCounters()), hash);
+
+            if (hash != singletonHeaderHash()) {
+                singletonHeaderHash() = hash;
+
+                // no result yet, print header
+                os << std::endl;
+                for (auto const& col : columns) {
+                    os << col.title();
+                }
+                os << "| " << mBench.title() << std::endl;
+
+                for (auto const& col : columns) {
+                    os << col.separator();
+                }
+                os << "|:" << std::string(mBench.title().size() + 1U, '-') << std::endl;
+            }
+
+            if (!errorMessage.empty()) {
+                for (auto const& col : columns) {
+                    os << col.invalid();
+                }
+                os << "| :boom: " << fmt::MarkDownCode(mBench.name()) << " (" << errorMessage << ')' << std::endl;
+            } else {
+                for (auto const& col : columns) {
+                    os << col.value();
+                }
+                os << "| ";
+                auto showUnstable = isWarningsEnabled() && rErrorMedian >= 0.05;
+                if (showUnstable) {
+                    os << ":wavy_dash: ";
+                }
+                os << fmt::MarkDownCode(mBench.name());
+                if (showUnstable) {
+                    auto avgIters = d(mTotalNumIters) / d(mBench.epochs());
+                    // NOLINTNEXTLINE(bugprone-incorrect-roundings)
+                    auto suggestedIters = static_cast<uint64_t>(avgIters * 10 + 0.5);
+
+                    os << " (Unstable with ~" << detail::fmt::Number(1, 1, avgIters)
+                       << " iters. Increase `minEpochIterations` to e.g. " << suggestedIters << ")";
+                }
+                os << std::endl;
+            }
+        }
+    }
+
+    ANKERL_NANOBENCH(NODISCARD) bool isCloseEnoughForMeasurements(std::chrono::nanoseconds elapsed) const noexcept {
+        return elapsed * 3 >= mTargetRuntimePerEpoch * 2;
+    }
+
+    uint64_t mNumIters = 1;                            // NOLINT(misc-non-private-member-variables-in-classes)
+    Bench const& mBench;                               // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mTargetRuntimePerEpoch{}; // NOLINT(misc-non-private-member-variables-in-classes)
+    Result mResult;                                    // NOLINT(misc-non-private-member-variables-in-classes)
+    Rng mRng{123};                                     // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mTotalElapsed{};          // NOLINT(misc-non-private-member-variables-in-classes)
+    uint64_t mTotalNumIters = 0;                       // NOLINT(misc-non-private-member-variables-in-classes)
+    State mState = State::upscaling_runtime;           // NOLINT(misc-non-private-member-variables-in-classes)
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+IterationLogic::IterationLogic(Bench const& bench)
+    : mPimpl(new Impl(bench)) {}
+
+IterationLogic::~IterationLogic() {
+    delete mPimpl;
+}
+
+uint64_t IterationLogic::numIters() const noexcept {
+    ANKERL_NANOBENCH_LOG(mPimpl->mBench.name() << ": mNumIters=" << mPimpl->mNumIters);
+    return mPimpl->mNumIters;
+}
+
+void IterationLogic::add(std::chrono::nanoseconds elapsed, PerformanceCounters const& pc) noexcept {
+    mPimpl->add(elapsed, pc);
+}
+
+void IterationLogic::moveResultTo(std::vector<Result>& results) noexcept {
+    results.emplace_back(std::move(mPimpl->mResult));
+}
+
+#    if ANKERL_NANOBENCH(PERF_COUNTERS)
+
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+class LinuxPerformanceCounters {
+public:
+    struct Target {
+        Target(uint64_t* targetValue_, bool correctMeasuringOverhead_, bool correctLoopOverhead_)
+            : targetValue(targetValue_)
+            , correctMeasuringOverhead(correctMeasuringOverhead_)
+            , correctLoopOverhead(correctLoopOverhead_) {}
+
+        uint64_t* targetValue{};         // NOLINT(misc-non-private-member-variables-in-classes)
+        bool correctMeasuringOverhead{}; // NOLINT(misc-non-private-member-variables-in-classes)
+        bool correctLoopOverhead{};      // NOLINT(misc-non-private-member-variables-in-classes)
+    };
+
+    LinuxPerformanceCounters() = default;
+    LinuxPerformanceCounters(LinuxPerformanceCounters const&) = delete;
+    LinuxPerformanceCounters(LinuxPerformanceCounters&&) = delete;
+    LinuxPerformanceCounters& operator=(LinuxPerformanceCounters const&) = delete;
+    LinuxPerformanceCounters& operator=(LinuxPerformanceCounters&&) = delete;
+    ~LinuxPerformanceCounters();
+
+    // quick operation
+    inline void start() {}
+
+    inline void stop() {}
+
+    bool monitor(perf_sw_ids swId, Target target);
+    bool monitor(perf_hw_id hwId, Target target);
+
+    ANKERL_NANOBENCH(NODISCARD) bool hasError() const noexcept {
+        return mHasError;
+    }
+
+    // Just reading data is faster than enable & disabling.
+    // we subtract data ourselves.
+    inline void beginMeasure() {
+        if (mHasError) {
+            return;
+        }
+
+        // NOLINTNEXTLINE(hicpp-signed-bitwise,cppcoreguidelines-pro-type-vararg)
+        mHasError = -1 == ioctl(mFd, PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
+        if (mHasError) {
+            return;
+        }
+
+        // NOLINTNEXTLINE(hicpp-signed-bitwise,cppcoreguidelines-pro-type-vararg)
+        mHasError = -1 == ioctl(mFd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
+    }
+
+    inline void endMeasure() {
+        if (mHasError) {
+            return;
+        }
+
+        // NOLINTNEXTLINE(hicpp-signed-bitwise,cppcoreguidelines-pro-type-vararg)
+        mHasError = (-1 == ioctl(mFd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP));
+        if (mHasError) {
+            return;
+        }
+
+        auto const numBytes = sizeof(uint64_t) * mCounters.size();
+        auto ret = read(mFd, mCounters.data(), numBytes);
+        mHasError = ret != static_cast<ssize_t>(numBytes);
+    }
+
+    void updateResults(uint64_t numIters);
+
+    // rounded integer division
+    template <typename T>
+    static inline T divRounded(T a, T divisor) {
+        return (a + divisor / 2) / divisor;
+    }
+
+    ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+    static inline uint32_t mix(uint32_t x) noexcept {
+        x ^= x << 13U;
+        x ^= x >> 17U;
+        x ^= x << 5U;
+        return x;
+    }
+
+    template <typename Op>
+    ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+    void calibrate(Op&& op) {
+        // clear current calibration data,
+        for (auto& v : mCalibratedOverhead) {
+            v = UINT64_C(0);
+        }
+
+        // create new calibration data
+        auto newCalibration = mCalibratedOverhead;
+        for (auto& v : newCalibration) {
+            v = (std::numeric_limits<uint64_t>::max)();
+        }
+        for (size_t iter = 0; iter < 100; ++iter) {
+            beginMeasure();
+            op();
+            endMeasure();
+            if (mHasError) {
+                return;
+            }
+
+            for (size_t i = 0; i < newCalibration.size(); ++i) {
+                auto diff = mCounters[i];
+                if (newCalibration[i] > diff) {
+                    newCalibration[i] = diff;
+                }
+            }
+        }
+
+        mCalibratedOverhead = std::move(newCalibration);
+
+        {
+            // calibrate loop overhead. For branches & instructions this makes sense, not so much for everything else like cycles.
+            // marsaglia's xorshift: mov, sal/shr, xor. Times 3.
+            // This has the nice property that the compiler doesn't seem to be able to optimize multiple calls any further.
+            // see https://godbolt.org/z/49RVQ5
+            uint64_t const numIters = 100000U + (std::random_device{}() & 3U);
+            uint64_t n = numIters;
+            uint32_t x = 1234567;
+
+            beginMeasure();
+            while (n-- > 0) {
+                x = mix(x);
+            }
+            endMeasure();
+            detail::doNotOptimizeAway(x);
+            auto measure1 = mCounters;
+
+            n = numIters;
+            beginMeasure();
+            while (n-- > 0) {
+                // we now run *twice* so we can easily calculate the overhead
+                x = mix(x);
+                x = mix(x);
+            }
+            endMeasure();
+            detail::doNotOptimizeAway(x);
+            auto measure2 = mCounters;
+
+            for (size_t i = 0; i < mCounters.size(); ++i) {
+                // factor 2 because we have two instructions per loop
+                auto m1 = measure1[i] > mCalibratedOverhead[i] ? measure1[i] - mCalibratedOverhead[i] : 0;
+                auto m2 = measure2[i] > mCalibratedOverhead[i] ? measure2[i] - mCalibratedOverhead[i] : 0;
+                auto overhead = m1 * 2 > m2 ? m1 * 2 - m2 : 0;
+
+                mLoopOverhead[i] = divRounded(overhead, numIters);
+            }
+        }
+    }
+
+private:
+    bool monitor(uint32_t type, uint64_t eventid, Target target);
+
+    std::map<uint64_t, Target> mIdToTarget{};
+
+    // start with minimum size of 3 for read_format
+    std::vector<uint64_t> mCounters{3};
+    std::vector<uint64_t> mCalibratedOverhead{3};
+    std::vector<uint64_t> mLoopOverhead{3};
+
+    uint64_t mTimeEnabledNanos = 0;
+    uint64_t mTimeRunningNanos = 0;
+    int mFd = -1;
+    bool mHasError = false;
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+LinuxPerformanceCounters::~LinuxPerformanceCounters() {
+    if (-1 != mFd) {
+        close(mFd);
+    }
+}
+
+bool LinuxPerformanceCounters::monitor(perf_sw_ids swId, LinuxPerformanceCounters::Target target) {
+    return monitor(PERF_TYPE_SOFTWARE, swId, target);
+}
+
+bool LinuxPerformanceCounters::monitor(perf_hw_id hwId, LinuxPerformanceCounters::Target target) {
+    return monitor(PERF_TYPE_HARDWARE, hwId, target);
+}
+
+// overflow is ok, it's checked
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+void LinuxPerformanceCounters::updateResults(uint64_t numIters) {
+    // clear old data
+    for (auto& id_value : mIdToTarget) {
+        *id_value.second.targetValue = UINT64_C(0);
+    }
+
+    if (mHasError) {
+        return;
+    }
+
+    mTimeEnabledNanos = mCounters[1] - mCalibratedOverhead[1];
+    mTimeRunningNanos = mCounters[2] - mCalibratedOverhead[2];
+
+    for (uint64_t i = 0; i < mCounters[0]; ++i) {
+        auto idx = static_cast<size_t>(3 + i * 2 + 0);
+        auto id = mCounters[idx + 1U];
+
+        auto it = mIdToTarget.find(id);
+        if (it != mIdToTarget.end()) {
+
+            auto& tgt = it->second;
+            *tgt.targetValue = mCounters[idx];
+            if (tgt.correctMeasuringOverhead) {
+                if (*tgt.targetValue >= mCalibratedOverhead[idx]) {
+                    *tgt.targetValue -= mCalibratedOverhead[idx];
+                } else {
+                    *tgt.targetValue = 0U;
+                }
+            }
+            if (tgt.correctLoopOverhead) {
+                auto correctionVal = mLoopOverhead[idx] * numIters;
+                if (*tgt.targetValue >= correctionVal) {
+                    *tgt.targetValue -= correctionVal;
+                } else {
+                    *tgt.targetValue = 0U;
+                }
+            }
+        }
+    }
+}
+
+bool LinuxPerformanceCounters::monitor(uint32_t type, uint64_t eventid, Target target) {
+    *target.targetValue = (std::numeric_limits<uint64_t>::max)();
+    if (mHasError) {
+        return false;
+    }
+
+    auto pea = perf_event_attr();
+    std::memset(&pea, 0, sizeof(perf_event_attr));
+    pea.type = type;
+    pea.size = sizeof(perf_event_attr);
+    pea.config = eventid;
+    pea.disabled = 1; // start counter as disabled
+    pea.exclude_kernel = 1;
+    pea.exclude_hv = 1;
+
+    // NOLINTNEXTLINE(hicpp-signed-bitwise)
+    pea.read_format = PERF_FORMAT_GROUP | PERF_FORMAT_ID | PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
+
+    const int pid = 0;                    // the current process
+    const int cpu = -1;                   // all CPUs
+#        if defined(PERF_FLAG_FD_CLOEXEC) // since Linux 3.14
+    const unsigned long flags = PERF_FLAG_FD_CLOEXEC;
+#        else
+    const unsigned long flags = 0;
+#        endif
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    auto fd = static_cast<int>(syscall(__NR_perf_event_open, &pea, pid, cpu, mFd, flags));
+    if (-1 == fd) {
+        return false;
+    }
+    if (-1 == mFd) {
+        // first call: set to fd, and use this from now on
+        mFd = fd;
+    }
+    uint64_t id = 0;
+    // NOLINTNEXTLINE(hicpp-signed-bitwise,cppcoreguidelines-pro-type-vararg)
+    if (-1 == ioctl(fd, PERF_EVENT_IOC_ID, &id)) {
+        // couldn't get id
+        return false;
+    }
+
+    // insert into map, rely on the fact that map's references are constant.
+    mIdToTarget.emplace(id, target);
+
+    // prepare readformat with the correct size (after the insert)
+    auto size = 3 + 2 * mIdToTarget.size();
+    mCounters.resize(size);
+    mCalibratedOverhead.resize(size);
+    mLoopOverhead.resize(size);
+
+    return true;
+}
+
+PerformanceCounters::PerformanceCounters()
+    : mPc(new LinuxPerformanceCounters())
+    , mVal()
+    , mHas() {
+
+    // HW events
+    mHas.cpuCycles = mPc->monitor(PERF_COUNT_HW_REF_CPU_CYCLES, LinuxPerformanceCounters::Target(&mVal.cpuCycles, true, false));
+    if (!mHas.cpuCycles) {
+        // Fallback to cycles counter, reference cycles not available in many systems.
+        mHas.cpuCycles = mPc->monitor(PERF_COUNT_HW_CPU_CYCLES, LinuxPerformanceCounters::Target(&mVal.cpuCycles, true, false));
+    }
+    mHas.instructions = mPc->monitor(PERF_COUNT_HW_INSTRUCTIONS, LinuxPerformanceCounters::Target(&mVal.instructions, true, true));
+    mHas.branchInstructions =
+        mPc->monitor(PERF_COUNT_HW_BRANCH_INSTRUCTIONS, LinuxPerformanceCounters::Target(&mVal.branchInstructions, true, false));
+    mHas.branchMisses = mPc->monitor(PERF_COUNT_HW_BRANCH_MISSES, LinuxPerformanceCounters::Target(&mVal.branchMisses, true, false));
+    // mHas.branchMisses = false;
+
+    // SW events
+    mHas.pageFaults = mPc->monitor(PERF_COUNT_SW_PAGE_FAULTS, LinuxPerformanceCounters::Target(&mVal.pageFaults, true, false));
+    mHas.contextSwitches =
+        mPc->monitor(PERF_COUNT_SW_CONTEXT_SWITCHES, LinuxPerformanceCounters::Target(&mVal.contextSwitches, true, false));
+
+    mPc->start();
+    mPc->calibrate([] {
+        auto before = ankerl::nanobench::Clock::now();
+        auto after = ankerl::nanobench::Clock::now();
+        (void)before;
+        (void)after;
+    });
+
+    if (mPc->hasError()) {
+        // something failed, don't monitor anything.
+        mHas = PerfCountSet<bool>{};
+    }
+}
+
+PerformanceCounters::~PerformanceCounters() {
+    // no need to check for nullptr, delete nullptr has no effect
+    delete mPc;
+}
+
+void PerformanceCounters::beginMeasure() {
+    mPc->beginMeasure();
+}
+
+void PerformanceCounters::endMeasure() {
+    mPc->endMeasure();
+}
+
+void PerformanceCounters::updateResults(uint64_t numIters) {
+    mPc->updateResults(numIters);
+}
+
+#    else
+
+PerformanceCounters::PerformanceCounters() = default;
+PerformanceCounters::~PerformanceCounters() = default;
+void PerformanceCounters::beginMeasure() {}
+void PerformanceCounters::endMeasure() {}
+void PerformanceCounters::updateResults(uint64_t) {}
+
+#    endif
+
+ANKERL_NANOBENCH(NODISCARD) PerfCountSet<uint64_t> const& PerformanceCounters::val() const noexcept {
+    return mVal;
+}
+ANKERL_NANOBENCH(NODISCARD) PerfCountSet<bool> const& PerformanceCounters::has() const noexcept {
+    return mHas;
+}
+
+// formatting utilities
+namespace fmt {
+
+// adds thousands separator to numbers
+NumSep::NumSep(char sep)
+    : mSep(sep) {}
+
+char NumSep::do_thousands_sep() const {
+    return mSep;
+}
+
+std::string NumSep::do_grouping() const {
+    return "\003";
+}
+
+// RAII to save & restore a stream's state
+StreamStateRestorer::StreamStateRestorer(std::ostream& s)
+    : mStream(s)
+    , mLocale(s.getloc())
+    , mPrecision(s.precision())
+    , mWidth(s.width())
+    , mFill(s.fill())
+    , mFmtFlags(s.flags()) {}
+
+StreamStateRestorer::~StreamStateRestorer() {
+    restore();
+}
+
+// sets back all stream info that we remembered at construction
+void StreamStateRestorer::restore() {
+    mStream.imbue(mLocale);
+    mStream.precision(mPrecision);
+    mStream.width(mWidth);
+    mStream.fill(mFill);
+    mStream.flags(mFmtFlags);
+}
+
+Number::Number(int width, int precision, int64_t value)
+    : mWidth(width)
+    , mPrecision(precision)
+    , mValue(d(value)) {}
+
+Number::Number(int width, int precision, double value)
+    : mWidth(width)
+    , mPrecision(precision)
+    , mValue(value) {}
+
+std::ostream& Number::write(std::ostream& os) const {
+    StreamStateRestorer const restorer(os);
+    os.imbue(std::locale(os.getloc(), new NumSep(',')));
+    os << std::setw(mWidth) << std::setprecision(mPrecision) << std::fixed << mValue;
+    return os;
+}
+
+std::string Number::to_s() const {
+    std::stringstream ss;
+    write(ss);
+    return ss.str();
+}
+
+std::string to_s(uint64_t n) {
+    std::string str;
+    do {
+        str += static_cast<char>('0' + static_cast<char>(n % 10));
+        n /= 10;
+    } while (n != 0);
+    std::reverse(str.begin(), str.end());
+    return str;
+}
+
+std::ostream& operator<<(std::ostream& os, Number const& n) {
+    return n.write(os);
+}
+
+MarkDownColumn::MarkDownColumn(int w, int prec, std::string tit, std::string suff, double val) noexcept
+    : mWidth(w)
+    , mPrecision(prec)
+    , mTitle(std::move(tit))
+    , mSuffix(std::move(suff))
+    , mValue(val) {}
+
+std::string MarkDownColumn::title() const {
+    std::stringstream ss;
+    ss << '|' << std::setw(mWidth - 2) << std::right << mTitle << ' ';
+    return ss.str();
+}
+
+std::string MarkDownColumn::separator() const {
+    std::string sep(static_cast<size_t>(mWidth), '-');
+    sep.front() = '|';
+    sep.back() = ':';
+    return sep;
+}
+
+std::string MarkDownColumn::invalid() const {
+    std::string sep(static_cast<size_t>(mWidth), ' ');
+    sep.front() = '|';
+    sep[sep.size() - 2] = '-';
+    return sep;
+}
+
+std::string MarkDownColumn::value() const {
+    std::stringstream ss;
+    auto width = mWidth - 2 - static_cast<int>(mSuffix.size());
+    ss << '|' << Number(width, mPrecision, mValue) << mSuffix << ' ';
+    return ss.str();
+}
+
+// Formats any text as markdown code, escaping backticks.
+MarkDownCode::MarkDownCode(std::string const& what) {
+    mWhat.reserve(what.size() + 2);
+    mWhat.push_back('`');
+    for (char const c : what) {
+        mWhat.push_back(c);
+        if ('`' == c) {
+            mWhat.push_back('`');
+        }
+    }
+    mWhat.push_back('`');
+}
+
+std::ostream& MarkDownCode::write(std::ostream& os) const {
+    return os << mWhat;
+}
+
+std::ostream& operator<<(std::ostream& os, MarkDownCode const& mdCode) {
+    return mdCode.write(os);
+}
+} // namespace fmt
+} // namespace detail
+
+// provide implementation here so it's only generated once
+Config::Config() = default;
+Config::~Config() = default;
+Config& Config::operator=(Config const&) = default;
+Config& Config::operator=(Config&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
+Config::Config(Config const&) = default;
+Config::Config(Config&&) noexcept = default;
+
+// provide implementation here so it's only generated once
+Result::~Result() = default;
+Result& Result::operator=(Result const&) = default;
+Result& Result::operator=(Result&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
+Result::Result(Result const&) = default;
+Result::Result(Result&&) noexcept = default;
+
+namespace detail {
+template <typename T>
+inline constexpr typename std::underlying_type<T>::type u(T val) noexcept {
+    return static_cast<typename std::underlying_type<T>::type>(val);
+}
+} // namespace detail
+
+// Result returned after a benchmark has finished. Can be used as a baseline for relative().
+Result::Result(Config benchmarkConfig)
+    : mConfig(std::move(benchmarkConfig))
+    , mNameToMeasurements{detail::u(Result::Measure::_size)} {}
+
+void Result::add(Clock::duration totalElapsed, uint64_t iters, detail::PerformanceCounters const& pc) {
+    using detail::d;
+    using detail::u;
+
+    double const dIters = d(iters);
+    mNameToMeasurements[u(Result::Measure::iterations)].push_back(dIters);
+
+    mNameToMeasurements[u(Result::Measure::elapsed)].push_back(d(totalElapsed) / dIters);
+    if (pc.has().pageFaults) {
+        mNameToMeasurements[u(Result::Measure::pagefaults)].push_back(d(pc.val().pageFaults) / dIters);
+    }
+    if (pc.has().cpuCycles) {
+        mNameToMeasurements[u(Result::Measure::cpucycles)].push_back(d(pc.val().cpuCycles) / dIters);
+    }
+    if (pc.has().contextSwitches) {
+        mNameToMeasurements[u(Result::Measure::contextswitches)].push_back(d(pc.val().contextSwitches) / dIters);
+    }
+    if (pc.has().instructions) {
+        mNameToMeasurements[u(Result::Measure::instructions)].push_back(d(pc.val().instructions) / dIters);
+    }
+    if (pc.has().branchInstructions) {
+        double branchInstructions = 0.0;
+        // correcting branches: remove branch introduced by the while (...) loop for each iteration.
+        if (pc.val().branchInstructions > iters + 1U) {
+            branchInstructions = d(pc.val().branchInstructions - (iters + 1U));
+        }
+        mNameToMeasurements[u(Result::Measure::branchinstructions)].push_back(branchInstructions / dIters);
+
+        if (pc.has().branchMisses) {
+            // correcting branch misses
+            double branchMisses = d(pc.val().branchMisses);
+            if (branchMisses > branchInstructions) {
+                // can't have branch misses when there were branches...
+                branchMisses = branchInstructions;
+            }
+
+            // assuming at least one missed branch for the loop
+            branchMisses -= 1.0;
+            if (branchMisses < 1.0) {
+                branchMisses = 1.0;
+            }
+            mNameToMeasurements[u(Result::Measure::branchmisses)].push_back(branchMisses / dIters);
+        }
+    }
+}
+
+Config const& Result::config() const noexcept {
+    return mConfig;
+}
+
+inline double calcMedian(std::vector<double>& data) {
+    if (data.empty()) {
+        return 0.0;
+    }
+    std::sort(data.begin(), data.end());
+
+    auto midIdx = data.size() / 2U;
+    if (1U == (data.size() & 1U)) {
+        return data[midIdx];
+    }
+    return (data[midIdx - 1U] + data[midIdx]) / 2U;
+}
+
+double Result::median(Measure m) const {
+    // create a copy so we can sort
+    auto data = mNameToMeasurements[detail::u(m)];
+    return calcMedian(data);
+}
+
+double Result::average(Measure m) const {
+    using detail::d;
+    auto const& data = mNameToMeasurements[detail::u(m)];
+    if (data.empty()) {
+        return 0.0;
+    }
+
+    // create a copy so we can sort
+    return sum(m) / d(data.size());
+}
+
+double Result::medianAbsolutePercentError(Measure m) const {
+    // create copy
+    auto data = mNameToMeasurements[detail::u(m)];
+
+    // calculates MdAPE which is the median of percentage error
+    // see https://support.numxl.com/hc/en-us/articles/115001223503-MdAPE-Median-Absolute-Percentage-Error
+    auto med = calcMedian(data);
+
+    // transform the data to absolute error
+    for (auto& x : data) {
+        x = (x - med) / x;
+        if (x < 0) {
+            x = -x;
+        }
+    }
+    return calcMedian(data);
+}
+
+double Result::sum(Measure m) const noexcept {
+    auto const& data = mNameToMeasurements[detail::u(m)];
+    return std::accumulate(data.begin(), data.end(), 0.0);
+}
+
+double Result::sumProduct(Measure m1, Measure m2) const noexcept {
+    auto const& data1 = mNameToMeasurements[detail::u(m1)];
+    auto const& data2 = mNameToMeasurements[detail::u(m2)];
+
+    if (data1.size() != data2.size()) {
+        return 0.0;
+    }
+
+    double result = 0.0;
+    for (size_t i = 0, s = data1.size(); i != s; ++i) {
+        result += data1[i] * data2[i];
+    }
+    return result;
+}
+
+bool Result::has(Measure m) const noexcept {
+    return !mNameToMeasurements[detail::u(m)].empty();
+}
+
+double Result::get(size_t idx, Measure m) const {
+    auto const& data = mNameToMeasurements[detail::u(m)];
+    return data.at(idx);
+}
+
+bool Result::empty() const noexcept {
+    return 0U == size();
+}
+
+size_t Result::size() const noexcept {
+    auto const& data = mNameToMeasurements[detail::u(Measure::elapsed)];
+    return data.size();
+}
+
+double Result::minimum(Measure m) const noexcept {
+    auto const& data = mNameToMeasurements[detail::u(m)];
+    if (data.empty()) {
+        return 0.0;
+    }
+
+    // here its save to assume that at least one element is there
+    return *std::min_element(data.begin(), data.end());
+}
+
+double Result::maximum(Measure m) const noexcept {
+    auto const& data = mNameToMeasurements[detail::u(m)];
+    if (data.empty()) {
+        return 0.0;
+    }
+
+    // here its save to assume that at least one element is there
+    return *std::max_element(data.begin(), data.end());
+}
+
+std::string const& Result::context(char const* variableName) const {
+    return mConfig.mContext.at(variableName);
+}
+
+std::string const& Result::context(std::string const& variableName) const {
+    return mConfig.mContext.at(variableName);
+}
+
+Result::Measure Result::fromString(std::string const& str) {
+    if (str == "elapsed") {
+        return Measure::elapsed;
+    }
+    if (str == "iterations") {
+        return Measure::iterations;
+    }
+    if (str == "pagefaults") {
+        return Measure::pagefaults;
+    }
+    if (str == "cpucycles") {
+        return Measure::cpucycles;
+    }
+    if (str == "contextswitches") {
+        return Measure::contextswitches;
+    }
+    if (str == "instructions") {
+        return Measure::instructions;
+    }
+    if (str == "branchinstructions") {
+        return Measure::branchinstructions;
+    }
+    if (str == "branchmisses") {
+        return Measure::branchmisses;
+    }
+    // not found, return _size
+    return Measure::_size;
+}
+
+// Configuration of a microbenchmark.
+Bench::Bench() {
+    mConfig.mOut = &std::cout;
+}
+
+Bench::Bench(Bench&&) noexcept = default;
+Bench& Bench::operator=(Bench&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
+Bench::Bench(Bench const&) = default;
+Bench& Bench::operator=(Bench const&) = default;
+Bench::~Bench() noexcept = default;
+
+double Bench::batch() const noexcept {
+    return mConfig.mBatch;
+}
+
+double Bench::complexityN() const noexcept {
+    return mConfig.mComplexityN;
+}
+
+// Set a baseline to compare it to. 100% it is exactly as fast as the baseline, >100% means it is faster than the baseline, <100%
+// means it is slower than the baseline.
+Bench& Bench::relative(bool isRelativeEnabled) noexcept {
+    mConfig.mIsRelative = isRelativeEnabled;
+    return *this;
+}
+bool Bench::relative() const noexcept {
+    return mConfig.mIsRelative;
+}
+
+Bench& Bench::performanceCounters(bool showPerformanceCounters) noexcept {
+    mConfig.mShowPerformanceCounters = showPerformanceCounters;
+    return *this;
+}
+bool Bench::performanceCounters() const noexcept {
+    return mConfig.mShowPerformanceCounters;
+}
+
+// Operation unit. Defaults to "op", could be e.g. "byte" for string processing.
+// If u differs from currently set unit, the stored results will be cleared.
+// Use singular (byte, not bytes).
+Bench& Bench::unit(char const* u) {
+    if (u != mConfig.mUnit) {
+        mResults.clear();
+    }
+    mConfig.mUnit = u;
+    return *this;
+}
+
+Bench& Bench::unit(std::string const& u) {
+    return unit(u.c_str());
+}
+
+std::string const& Bench::unit() const noexcept {
+    return mConfig.mUnit;
+}
+
+Bench& Bench::timeUnit(std::chrono::duration<double> const& tu, std::string const& tuName) {
+    mConfig.mTimeUnit = tu;
+    mConfig.mTimeUnitName = tuName;
+    return *this;
+}
+
+std::string const& Bench::timeUnitName() const noexcept {
+    return mConfig.mTimeUnitName;
+}
+
+std::chrono::duration<double> const& Bench::timeUnit() const noexcept {
+    return mConfig.mTimeUnit;
+}
+
+// If benchmarkTitle differs from currently set title, the stored results will be cleared.
+Bench& Bench::title(const char* benchmarkTitle) {
+    if (benchmarkTitle != mConfig.mBenchmarkTitle) {
+        mResults.clear();
+    }
+    mConfig.mBenchmarkTitle = benchmarkTitle;
+    return *this;
+}
+Bench& Bench::title(std::string const& benchmarkTitle) {
+    if (benchmarkTitle != mConfig.mBenchmarkTitle) {
+        mResults.clear();
+    }
+    mConfig.mBenchmarkTitle = benchmarkTitle;
+    return *this;
+}
+
+std::string const& Bench::title() const noexcept {
+    return mConfig.mBenchmarkTitle;
+}
+
+Bench& Bench::name(const char* benchmarkName) {
+    mConfig.mBenchmarkName = benchmarkName;
+    return *this;
+}
+
+Bench& Bench::name(std::string const& benchmarkName) {
+    mConfig.mBenchmarkName = benchmarkName;
+    return *this;
+}
+
+std::string const& Bench::name() const noexcept {
+    return mConfig.mBenchmarkName;
+}
+
+Bench& Bench::context(char const* variableName, char const* variableValue) {
+    mConfig.mContext[variableName] = variableValue;
+    return *this;
+}
+
+Bench& Bench::context(std::string const& variableName, std::string const& variableValue) {
+    mConfig.mContext[variableName] = variableValue;
+    return *this;
+}
+
+Bench& Bench::clearContext() {
+    mConfig.mContext.clear();
+    return *this;
+}
+
+// Number of epochs to evaluate. The reported result will be the median of evaluation of each epoch.
+Bench& Bench::epochs(size_t numEpochs) noexcept {
+    mConfig.mNumEpochs = numEpochs;
+    return *this;
+}
+size_t Bench::epochs() const noexcept {
+    return mConfig.mNumEpochs;
+}
+
+// Desired evaluation time is a multiple of clock resolution. Default is to be 1000 times above this measurement precision.
+Bench& Bench::clockResolutionMultiple(size_t multiple) noexcept {
+    mConfig.mClockResolutionMultiple = multiple;
+    return *this;
+}
+size_t Bench::clockResolutionMultiple() const noexcept {
+    return mConfig.mClockResolutionMultiple;
+}
+
+// Sets the maximum time each epoch should take. Default is 100ms.
+Bench& Bench::maxEpochTime(std::chrono::nanoseconds t) noexcept {
+    mConfig.mMaxEpochTime = t;
+    return *this;
+}
+std::chrono::nanoseconds Bench::maxEpochTime() const noexcept {
+    return mConfig.mMaxEpochTime;
+}
+
+// Sets the maximum time each epoch should take. Default is 100ms.
+Bench& Bench::minEpochTime(std::chrono::nanoseconds t) noexcept {
+    mConfig.mMinEpochTime = t;
+    return *this;
+}
+std::chrono::nanoseconds Bench::minEpochTime() const noexcept {
+    return mConfig.mMinEpochTime;
+}
+
+Bench& Bench::minEpochIterations(uint64_t numIters) noexcept {
+    mConfig.mMinEpochIterations = (numIters == 0) ? 1 : numIters;
+    return *this;
+}
+uint64_t Bench::minEpochIterations() const noexcept {
+    return mConfig.mMinEpochIterations;
+}
+
+Bench& Bench::epochIterations(uint64_t numIters) noexcept {
+    mConfig.mEpochIterations = numIters;
+    return *this;
+}
+uint64_t Bench::epochIterations() const noexcept {
+    return mConfig.mEpochIterations;
+}
+
+Bench& Bench::warmup(uint64_t numWarmupIters) noexcept {
+    mConfig.mWarmup = numWarmupIters;
+    return *this;
+}
+uint64_t Bench::warmup() const noexcept {
+    return mConfig.mWarmup;
+}
+
+Bench& Bench::config(Config const& benchmarkConfig) {
+    mConfig = benchmarkConfig;
+    return *this;
+}
+Config const& Bench::config() const noexcept {
+    return mConfig;
+}
+
+Bench& Bench::output(std::ostream* outstream) noexcept {
+    mConfig.mOut = outstream;
+    return *this;
+}
+
+ANKERL_NANOBENCH(NODISCARD) std::ostream* Bench::output() const noexcept {
+    return mConfig.mOut;
+}
+
+std::vector<Result> const& Bench::results() const noexcept {
+    return mResults;
+}
+
+Bench& Bench::render(char const* templateContent, std::ostream& os) {
+    ::ankerl::nanobench::render(templateContent, *this, os);
+    return *this;
+}
+
+Bench& Bench::render(std::string const& templateContent, std::ostream& os) {
+    ::ankerl::nanobench::render(templateContent, *this, os);
+    return *this;
+}
+
+std::vector<BigO> Bench::complexityBigO() const {
+    std::vector<BigO> bigOs;
+    auto rangeMeasure = BigO::collectRangeMeasure(mResults);
+    bigOs.emplace_back("O(1)", rangeMeasure, [](double) {
+        return 1.0;
+    });
+    bigOs.emplace_back("O(n)", rangeMeasure, [](double n) {
+        return n;
+    });
+    bigOs.emplace_back("O(log n)", rangeMeasure, [](double n) {
+        return std::log2(n);
+    });
+    bigOs.emplace_back("O(n log n)", rangeMeasure, [](double n) {
+        return n * std::log2(n);
+    });
+    bigOs.emplace_back("O(n^2)", rangeMeasure, [](double n) {
+        return n * n;
+    });
+    bigOs.emplace_back("O(n^3)", rangeMeasure, [](double n) {
+        return n * n * n;
+    });
+    std::sort(bigOs.begin(), bigOs.end());
+    return bigOs;
+}
+
+Rng::Rng()
+    : mX(0)
+    , mY(0) {
+    std::random_device rd;
+    std::uniform_int_distribution<uint64_t> dist;
+    do {
+        mX = dist(rd);
+        mY = dist(rd);
+    } while (mX == 0 && mY == 0);
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+uint64_t splitMix64(uint64_t& state) noexcept {
+    uint64_t z = (state += UINT64_C(0x9e3779b97f4a7c15));
+    z = (z ^ (z >> 30U)) * UINT64_C(0xbf58476d1ce4e5b9);
+    z = (z ^ (z >> 27U)) * UINT64_C(0x94d049bb133111eb);
+    return z ^ (z >> 31U);
+}
+
+// Seeded as described in romu paper (update april 2020)
+Rng::Rng(uint64_t seed) noexcept
+    : mX(splitMix64(seed))
+    , mY(splitMix64(seed)) {
+    for (size_t i = 0; i < 10; ++i) {
+        operator()();
+    }
+}
+
+// only internally used to copy the RNG.
+Rng::Rng(uint64_t x, uint64_t y) noexcept
+    : mX(x)
+    , mY(y) {}
+
+Rng Rng::copy() const noexcept {
+    return Rng{mX, mY};
+}
+
+Rng::Rng(std::vector<uint64_t> const& data)
+    : mX(0)
+    , mY(0) {
+    if (data.size() != 2) {
+        throw std::runtime_error("ankerl::nanobench::Rng::Rng: needed exactly 2 entries in data, but got " +
+                                 detail::fmt::to_s(data.size()));
+    }
+    mX = data[0];
+    mY = data[1];
+}
+
+std::vector<uint64_t> Rng::state() const {
+    std::vector<uint64_t> data(2);
+    data[0] = mX;
+    data[1] = mY;
+    return data;
+}
+
+BigO::RangeMeasure BigO::collectRangeMeasure(std::vector<Result> const& results) {
+    BigO::RangeMeasure rangeMeasure;
+    for (auto const& result : results) {
+        if (result.config().mComplexityN > 0.0) {
+            rangeMeasure.emplace_back(result.config().mComplexityN, result.median(Result::Measure::elapsed));
+        }
+    }
+    return rangeMeasure;
+}
+
+BigO::BigO(std::string bigOName, RangeMeasure const& rangeMeasure)
+    : mName(std::move(bigOName)) {
+
+    // estimate the constant factor
+    double sumRangeMeasure = 0.0;
+    double sumRangeRange = 0.0;
+
+    for (const auto& rm : rangeMeasure) {
+        sumRangeMeasure += rm.first * rm.second;
+        sumRangeRange += rm.first * rm.first;
+    }
+    mConstant = sumRangeMeasure / sumRangeRange;
+
+    // calculate root mean square
+    double err = 0.0;
+    double sumMeasure = 0.0;
+    for (const auto& rm : rangeMeasure) {
+        auto diff = mConstant * rm.first - rm.second;
+        err += diff * diff;
+
+        sumMeasure += rm.second;
+    }
+
+    auto n = detail::d(rangeMeasure.size());
+    auto mean = sumMeasure / n;
+    mNormalizedRootMeanSquare = std::sqrt(err / n) / mean;
+}
+
+BigO::BigO(const char* bigOName, RangeMeasure const& rangeMeasure)
+    : BigO(std::string(bigOName), rangeMeasure) {}
+
+std::string const& BigO::name() const noexcept {
+    return mName;
+}
+
+double BigO::constant() const noexcept {
+    return mConstant;
+}
+
+double BigO::normalizedRootMeanSquare() const noexcept {
+    return mNormalizedRootMeanSquare;
+}
+
+bool BigO::operator<(BigO const& other) const noexcept {
+    return std::tie(mNormalizedRootMeanSquare, mName) < std::tie(other.mNormalizedRootMeanSquare, other.mName);
+}
+
+std::ostream& operator<<(std::ostream& os, BigO const& bigO) {
+    return os << bigO.constant() << " * " << bigO.name() << ", rms=" << bigO.normalizedRootMeanSquare();
+}
+
+std::ostream& operator<<(std::ostream& os, std::vector<ankerl::nanobench::BigO> const& bigOs) {
+    detail::fmt::StreamStateRestorer const restorer(os);
+    os << std::endl << "|   coefficient |   err% | complexity" << std::endl << "|--------------:|-------:|------------" << std::endl;
+    for (auto const& bigO : bigOs) {
+        os << "|" << std::setw(14) << std::setprecision(7) << std::scientific << bigO.constant() << " ";
+        os << "|" << detail::fmt::Number(6, 1, bigO.normalizedRootMeanSquare() * 100.0) << "% ";
+        os << "| " << bigO.name();
+        os << std::endl;
+    }
+    return os;
+}
+
+} // namespace nanobench
+} // namespace ankerl
+
+#endif // ANKERL_NANOBENCH_IMPLEMENT
+#endif // ANKERL_NANOBENCH_H_INCLUDED


### PR DESCRIPTION
## Summary

Prepares **v0.9.0** on top of the C++20 modernization: performance optimizations (measured),
release tooling (install/export, versioning, license attribution), a real test framework, and
correctness/edge-case coverage. Targets `master` after the modernization PR.

## Performance (Tier 0)

- **`compute_core_dist` ~2.2–2.7×** faster: reuse a `thread_local` squared-distance buffer
  instead of copying the index list and `nth_element`-ing by a key comparator.
- **Lazy-deletion min-heap seed queue (~14–17% faster ordering)** replacing the per-point
  `std::set` — reproduces the exact pop order, removes per-insert node allocation.
- Investigated and **rejected with data** (parked): distance-pass fusion and CSR neighbor
  storage — both performance-neutral because OPTICS is query-bound at scale.
- Validated to **1e7 points** (3D); baselines in `perf/README.md`.

## Release readiness (Tier 1)

- **CMake install/export + package config** — verified a `find_package(optics 0.9)` consumer
  builds and runs.
- **Versioning**: project VERSION 0.9.0, `optics/version.hpp`, `CHANGELOG.md`.
- **API surface frozen** — internals moved into `optics::detail`.
- **Convenience helpers**: `cluster_dbscan`, `extract_xi`, `convert_cloud<float>` (uint8/int → float).
- **`THIRD-PARTY-LICENSES`** — nanoflann (BSD-2) + test-only doctest/nanobench (MIT); our license stays MIT.

## Testing (Tier 2 + foundations)

- Unit suite migrated to **doctest**; **nanobench** perf-regression harness with a committed baseline.
- **Brute-force O(n²) reference test** — library matches a naive OPTICS bit-for-bit.
- **Edge cases**: empty input, `min_pts==0` throws, `<min_pts` points, all-identical, collinear
  separation, float/double parity, multi-thread determinism.
- Fixed `epsilon_estimation` to use effective (non-degenerate) dimensions — no more zero-volume
  collapse on collinear/planar inputs.

CI green on Linux GCC/Clang, Windows MSVC, and the Boost-backend job.
