### PR TITLE
Fix CI: pin Windows to VS2022 image + correct python smoke-test path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
             preset: linux-clang
             werror: "OFF"
           - name: Windows MSVC
-            os: windows-latest
+            # Pinned: the `msvc` preset uses the "Visual Studio 17 2022" generator (matching the
+            # documented MSVC 2022 toolchain), which the windows-latest image no longer provides
+            # since it moved to VS2026 -- cmake then fails at project(). windows-2022 keeps CI and
+            # local dev on the same generator. Bump the preset + this image together when moving to VS2026.
+            os: windows-2022
             preset: msvc
             werror: "ON"
     steps:
@@ -84,7 +88,10 @@ jobs:
         run: cmake --build build-py
 
       - name: Smoke test
-        run: python python/test_optics_py.py build-py/python
+        # The in-tree build drops _optics.*.so under build-py/python; the native smoke test imports
+        # it from that dir (argv[1]). (Was python/test_optics_py.py, moved to python/tests/ in the
+        # test reorg.)
+        run: python python/tests/test_native.py build-py/python
 
   sanitizers:
     name: Linux Clang ASan+UBSan


### PR DESCRIPTION
## Summary

Fixes the two pre-existing CI failures that are red on `master` (both unrelated to clustering code):

1. **Windows MSVC** — the `msvc` preset pins the `Visual Studio 17 2022` generator, but `windows-latest` moved to the **VS2026** runner image, so `cmake` fails at `project()`. Pin the job to `windows-2022` to keep CI on the same generator as the documented MSVC 2022 dev toolchain.
2. **Python binding** — the smoke-test step still invoked the deleted `python/test_optics_py.py` (moved to `python/tests/test_native.py` in the test reorg `8576624`); the build passed but the script was gone (exit 2). Point the step at the new path (same `argv[1]` = built-module dir).

## Verification
- `ci.yml` validated as well-formed YAML.
- The fix is CI-config only; the actual checks (Windows configure/build/test, the Linux native smoke test) run on this PR and should now be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
