### PR TITLE
test(hdbscan): concurrent thread-safety regression for #68

### DIFF
--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -20,6 +20,7 @@
 #include <optional>
 #include <random>
 #include <set>
+#include <thread>
 #include <vector>
 
 
@@ -1797,6 +1798,42 @@ TEST_CASE("hdbscan: separated blobs -> exact cluster count, agrees with ground t
 	// Deterministic: identical input => identical labelling.
 	const auto again = optics::hdbscan( pts, 5 );
 	CHECK( ( res.labels == again.labels ) );
+}
+
+
+TEST_CASE("hdbscan: concurrent calls are thread-safe (issue #68 regression)") {
+	// Regression for #68: cluster_image -> exact hdbscan (dedup) crashed when fanned across a thread
+	// pool on photo-like clouds. The fix is per-thread (thread_local) scratch in the core-distance
+	// scan (#55), so neither concurrent top-level calls nor each call's internal parallel
+	// core-distance threads race. hdbscan is deterministic for a fixed input, so every concurrent
+	// result must equal its sequential reference; under the ASan/UBSan CI job this same case also
+	// surfaces any data race / use-after-free in the parallel paths.
+	constexpr int kClouds = 4;
+	const std::vector<std::array<double, 3>> centers = { { 0, 0, 0 }, { 80, 0, 0 }, { 40, 70, 10 } };
+	std::vector<std::vector<std::array<double, 3>>> clouds;
+	for ( int c = 0; c < kClouds; ++c ) {
+		auto pts = optics::testdata::gaussian_blobs<double, 3>( centers, 70, 2.0 );
+		const auto noise = optics::testdata::uniform_noise<double, 3>( 40, -40.0, 110.0, 100 + c );
+		pts.insert( pts.end(), noise.begin(), noise.end() );  // noise-heavy, like a real photo
+		clouds.push_back( std::move( pts ) );
+	}
+
+	// Sequential references: the labelling each concurrent run must reproduce bit-for-bit.
+	std::vector<optics::HdbscanResult> refs;
+	for ( const auto& cloud : clouds ) { refs.push_back( optics::hdbscan( cloud, 10 ) ); }
+
+	for ( int round = 0; round < 3; ++round ) {
+		std::vector<optics::HdbscanResult> out( kClouds );
+		std::vector<std::thread> ws;
+		for ( int c = 0; c < kClouds; ++c ) {
+			ws.emplace_back( [&, c] { out[c] = optics::hdbscan( clouds[c], 10 ); } );
+		}
+		for ( auto& w : ws ) { w.join(); }
+		for ( int c = 0; c < kClouds; ++c ) {
+			CHECK( ( out[c].labels == refs[c].labels ) );
+			CHECK( out[c].n_clusters == refs[c].n_clusters );
+		}
+	}
 }
 
 


### PR DESCRIPTION
## Summary

Adds a regression test for **#68** (concurrent `cluster_image`/`hdbscan` segfault). The crash was reported on the **0.9.1 `feat/python-color-api`** build and **no longer reproduces on master** — this guards against it coming back.

## Investigation (current master)

| Check | Result |
|---|---|
| Pure-C++ concurrent `hdbscan`, all MST backbones (denseprim/boruvka/knngraph/auto), 6 threads × rounds | ✅ no crash |
| AddressSanitizer (sequential + concurrent) | ✅ no memory errors |
| Reporter's **exact Python repro** (`cluster_image` × 6-worker pool) on a freshly built `cp314` binding | ✅ no crash, reproduces their cluster counts |

Root cause of the original crash was almost certainly the **#55** refactor that made `compute_core_dist` fill a `thread_local` buffer instead of a shared one (the internal `parallel_for` workers raced on it); the hot-path buffers are all `thread_local` today.

## The test

A doctest case runs `optics::hdbscan` concurrently from several threads on noise-heavy blob clouds and asserts each concurrent result equals its sequential reference (hdbscan is deterministic for fixed input). Under the **ASan/UBSan CI job** the same case also surfaces any data race / use-after-free in the parallel core-distance and MST paths. Suite: 69/69 cases pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
